### PR TITLE
fix: Add support for spaces in county names in "prepare" configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,5 @@ elephant-cli*.log
 prepare/layers/
 workflow/lambdas/post/transforms.zip
 
+set_alachua_envs.sh
+set_sarasota_envs.sh

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ export ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_Sarasota='{"timeout": 60000, "se
 # Charlotte County - simple browser mode, no template needed
 export ELEPHANT_PREPARE_USE_BROWSER_Charlotte=true
 
+# Santa Rosa County - note the underscore for the space
+export ELEPHANT_PREPARE_USE_BROWSER_Santa_Rosa=true
+export ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Santa_Rosa="SANTA_ROSA_FLOW"
+export ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_Santa_Rosa='{"timeout": 45000}'
+
+# Palm Beach County - another example with space in name
+export ELEPHANT_PREPARE_USE_BROWSER_Palm_Beach=true
+export ELEPHANT_PREPARE_NO_FAST_Palm_Beach=true
+
 # Broward County - uses general settings (no browser mode)
 # No county-specific settings needed
 
@@ -154,6 +163,8 @@ When the Lambda processes data:
 - Alachua inputs → Uses browser mode with SEARCH_BY_PARCEL_ID template
 - Sarasota inputs → Uses browser mode with CUSTOM_SEARCH template and no-fast mode
 - Charlotte inputs → Uses simple browser mode
+- Santa Rosa inputs → Uses browser mode with SANTA_ROSA_FLOW template (county with space in name)
+- Palm Beach inputs → Uses browser mode with no-fast flag (county with space in name)
 - Broward inputs → Uses general settings (no browser mode)
 - Any other county → Uses general settings
 
@@ -178,7 +189,15 @@ export ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Charlotte="CHARLOTTE_FLOW"
 - `ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_<CountyName>`
 - `ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_<CountyName>`
 
-**Note:** County names in environment variables should match exactly as they appear in `county_jurisdiction` field (case-sensitive). For example, if the JSON contains `"county_jurisdiction": "Alachua"`, use `_Alachua` suffix.
+**Important naming convention for counties with spaces:**
+
+For counties with spaces in their names, replace spaces with underscores in the environment variable name:
+
+- `"Santa Rosa"` → `ELEPHANT_PREPARE_USE_BROWSER_Santa_Rosa`
+- `"Palm Beach"` → `ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Palm_Beach`
+- `"San Diego"` → `ELEPHANT_PREPARE_NO_FAST_San_Diego`
+
+The Lambda automatically handles this conversion when matching county names from the data.
 
 #### Browser Flow Template Configuration
 
@@ -247,24 +266,22 @@ The Lambda logs will show exactly which configuration is being used for each cou
 
 ```
 📍 Extracting county information from input...
-✅ Detected county: Alachua
+✅ Detected county: Santa Rosa
 Building prepare options...
 Event browser setting: undefined (using: true)
 Checking environment variables for prepare flags:
-🏛️ Looking for county-specific configurations for: Alachua
-  Using county-specific: ELEPHANT_PREPARE_USE_BROWSER_Alachua='true'
+🏛️ Looking for county-specific configurations for: Santa Rosa
+  Using county-specific: ELEPHANT_PREPARE_USE_BROWSER_Santa_Rosa='true'
 ✓ Setting useBrowser: true (Force browser mode)
   Using general: ELEPHANT_PREPARE_NO_FAST='false'
 ✗ Not setting noFast flag (Disable fast mode)
-  Using county-specific: ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Alachua='SEARCH_BY_PARCEL_ID'
+  Using county-specific: ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Santa_Rosa='SANTA_ROSA_FLOW'
 Browser flow template configuration detected:
-✓ ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE='SEARCH_BY_PARCEL_ID'
-  Using county-specific: ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_Alachua='continue_button_selector:.btn.btn-primary.button-1,search_form_selector:#ctlBodyPane_ctl03_ctl01_txtParcelID,search_result_selector:#ctlBodyPane_ctl10_ctl01_lstBuildings_ctl00_dynamicBuildingDataRightColumn_divSummary'
+✓ ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE='SANTA_ROSA_FLOW'
+  Using county-specific: ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_Santa_Rosa='timeout:45000'
 ✓ ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS parsed successfully:
 {
-  "continue_button_selector": ".btn.btn-primary.button-1",
-  "search_form_selector": "#ctlBodyPane_ctl03_ctl01_txtParcelID",
-  "search_result_selector": "#ctlBodyPane_ctl10_ctl01_lstBuildings_ctl00_dynamicBuildingDataRightColumn_divSummary"
+  "timeout": 45000
 }
 Calling prepare() with these options...
 ```

--- a/prepare/lambdas/downloader/index.mjs
+++ b/prepare/lambdas/downloader/index.mjs
@@ -266,7 +266,10 @@ export const handler = async (event) => {
      */
     const getEnvWithCountyFallback = (baseEnvVar, countyName) => {
       if (countyName) {
-        const countySpecificVar = `${baseEnvVar}_${countyName}`;
+        // Replace spaces with underscores for environment variable names
+        // e.g., "Santa Rosa" becomes "Santa_Rosa"
+        const sanitizedCountyName = countyName.replace(/ /g, "_");
+        const countySpecificVar = `${baseEnvVar}_${sanitizedCountyName}`;
         if (process.env[countySpecificVar] !== undefined) {
           console.log(
             `  Using county-specific: ${countySpecificVar}='${process.env[countySpecificVar]}'`,

--- a/scripts/set-county-configs.sh
+++ b/scripts/set-county-configs.sh
@@ -144,7 +144,7 @@ main() {
       # Display the county-specific variables that were set
       echo
       info "County-specific configurations:"
-      echo "$new_env_json" | jq -r 'to_entries[] | select(.key | test("_(Alachua|Sarasota|Broward|Charlotte|Duval|Hillsborough|Lake|Lee|Leon|Manatee|PalmBeach|Pinellas|Polk|Santa|[A-Za-z]+)$")) | "  \(.key)=\(.value)"'
+      echo "$new_env_json" | jq -r 'to_entries[] | select(.key | test("_[A-Za-z_]+$")) | select(.key | test("^ELEPHANT_PREPARE_")) | "  \(.key)=\(.value)"'
     else
       err "Failed to update Lambda environment variables"
       exit 1
@@ -155,6 +155,10 @@ main() {
     echo "  export ELEPHANT_PREPARE_USE_BROWSER_Alachua=true"
     echo "  export ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Sarasota=SEARCH_BY_PARCEL"
     echo "  export ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS_Sarasota='{\"timeout\": 30000}'"
+    echo ""
+    echo "Note: For counties with spaces in their names, use underscores:"
+    echo "  export ELEPHANT_PREPARE_USE_BROWSER_Santa_Rosa=true"
+    echo "  export ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE_Palm_Beach=CUSTOM_FLOW"
   fi
 }
 


### PR DESCRIPTION

- Updated README.md to include environment variable configurations for Santa Rosa and Palm Beach counties, emphasizing the use of underscores for spaces in county names.
- Modified downloader lambda to sanitize county names by replacing spaces with underscores when constructing environment variable names.
- Enhanced set-county-configs.sh script to display correct export commands for counties with spaces.