### PR TITLE
feat: add support for county-specific browser flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ export ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS=""  # Browser flow parameters as
 - When using keystore mode, you don't need to provide: `ELEPHANT_DOMAIN`, `ELEPHANT_API_KEY`, `ELEPHANT_ORACLE_KEY_ID`, or `ELEPHANT_FROM_ADDRESS`
 - To create a keystore file, see the [Elephant CLI documentation on encrypted JSON keystores](https://github.com/elephant-xyz/elephant-cli?tab=readme-ov-file#encrypted-json-keystore)
 
+**Browser Flow Files (Optional):**
+
+For complex browser automation scenarios, you can provide county-specific browser flow JSON files:
+
+1. Add JSON files named `<CountyName>.json` (e.g., `Broward.json`, `Miami-Dade.json`) to the `browser-flows/` directory in the repository root
+2. These files are automatically uploaded to S3 during deployment
+3. The Lambda function will automatically download and use the appropriate flow file based on the county being processed
+
+Example structure:
+```
+oracle-node/
+├── browser-flows/
+│   ├── Broward.json
+│   ├── Miami-Dade.json
+│   └── Palm-Beach.json
+├── transform/
+└── ...
+```
+
+The browser flow file is passed to the prepare function as the `browserFlowFile` parameter and is automatically cleaned up after use.
+
 Put your transform files under `transform/` (if applicable).
 
 ### 2) Deploy infrastructure

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For complex browser automation scenarios, you can provide county-specific browse
 3. The Lambda function will automatically download and use the appropriate flow file based on the county being processed
 
 Example structure:
+
 ```
 oracle-node/
 ├── browser-flows/

--- a/browser-flows/Washington.json
+++ b/browser-flows/Washington.json
@@ -1,66 +1,65 @@
 {
-    "starts_at": "open_page",
-    "states": {
-      "open_page": {
-        "type": "open_page",
-        "input": {
-          "url": "{{=it.url}}",
-          "timeout": 30000,
-          "wait_until": "domcontentloaded"
-        },
-        "next": "wait_for_continue_button"
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}",
+        "timeout": 30000,
+        "wait_until": "domcontentloaded"
       },
-      "wait_for_continue_button": {
-        "type": "wait_for_selector",
-        "input": {
-          "selector": ".btn.btn-primary.button-1",
-          "timeout": 15000,
-          "visible": true
-        },
-        "next": "click_continue_button"
+      "next": "wait_for_continue_button"
+    },
+    "wait_for_continue_button": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": ".btn.btn-primary.button-1",
+        "timeout": 15000,
+        "visible": true
       },
-      "click_continue_button": {
-        "type": "click",
-        "input": {
-          "selector": ".btn.btn-primary.button-1"
-        },
-        "next": "wait_for_search_form"
+      "next": "click_continue_button"
+    },
+    "click_continue_button": {
+      "type": "click",
+      "input": {
+        "selector": ".btn.btn-primary.button-1"
       },
-      "wait_for_search_form": {
-        "type": "wait_for_selector",
-        "input": {
-          "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
-          "timeout": 30000,
-          "visible": true
-        },
-        "next": "enter_parcel_id"
+      "next": "wait_for_search_form"
+    },
+    "wait_for_search_form": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
+        "timeout": 30000,
+        "visible": true
       },
-      "enter_parcel_id": {
-        "type": "type",
-        "input": {
-          "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
-          "value": "{{=it.request_identifier}}",
-          "clear": true,
-          "delay": 100
-        },
-        "next": "submit_search"
+      "next": "enter_parcel_id"
+    },
+    "enter_parcel_id": {
+      "type": "type",
+      "input": {
+        "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
+        "value": "{{=it.request_identifier}}",
+        "clear": true,
+        "delay": 100
       },
-      "submit_search": {
-        "type": "keyboard_press",
-        "input": {
-          "key": "Enter"
-        },
-        "next": "wait_for_results"
+      "next": "submit_search"
+    },
+    "submit_search": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
       },
-      "wait_for_results": {
-        "type": "wait_for_selector",
-        "input": {
-          "selector": "#ctlBodyPane_ctl00_mSection",
-          "timeout": 60000,
-          "visible": true
-        },
-        "end": true
-      }
+      "next": "wait_for_results"
+    },
+    "wait_for_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "#ctlBodyPane_ctl00_mSection",
+        "timeout": 60000,
+        "visible": true
+      },
+      "end": true
     }
   }
-  
+}

--- a/browser-flows/Washington.json
+++ b/browser-flows/Washington.json
@@ -1,0 +1,66 @@
+{
+    "starts_at": "open_page",
+    "states": {
+      "open_page": {
+        "type": "open_page",
+        "input": {
+          "url": "{{=it.url}}",
+          "timeout": 30000,
+          "wait_until": "domcontentloaded"
+        },
+        "next": "wait_for_continue_button"
+      },
+      "wait_for_continue_button": {
+        "type": "wait_for_selector",
+        "input": {
+          "selector": ".btn.btn-primary.button-1",
+          "timeout": 15000,
+          "visible": true
+        },
+        "next": "click_continue_button"
+      },
+      "click_continue_button": {
+        "type": "click",
+        "input": {
+          "selector": ".btn.btn-primary.button-1"
+        },
+        "next": "wait_for_search_form"
+      },
+      "wait_for_search_form": {
+        "type": "wait_for_selector",
+        "input": {
+          "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
+          "timeout": 30000,
+          "visible": true
+        },
+        "next": "enter_parcel_id"
+      },
+      "enter_parcel_id": {
+        "type": "type",
+        "input": {
+          "selector": "#ctlBodyPane_ctl02_ctl01_txtParcelID",
+          "value": "{{=it.request_identifier}}",
+          "clear": true,
+          "delay": 100
+        },
+        "next": "submit_search"
+      },
+      "submit_search": {
+        "type": "keyboard_press",
+        "input": {
+          "key": "Enter"
+        },
+        "next": "wait_for_results"
+      },
+      "wait_for_results": {
+        "type": "wait_for_selector",
+        "input": {
+          "selector": "#ctlBodyPane_ctl00_mSection",
+          "timeout": 60000,
+          "visible": true
+        },
+        "end": true
+      }
+    }
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@elephant-xyz/cli": {
-      "version": "1.46.5",
-      "resolved": "https://registry.npmjs.org/@elephant-xyz/cli/-/cli-1.46.5.tgz",
-      "integrity": "sha512-+jtewhjBwfqKL0Ul4HIeiSXSelfwle5UF7gkth8o2abyvAfnU2MZtfqaWc8iOWY7jO3qX99SsuaDm0Cxm85ytQ==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@elephant-xyz/cli/-/cli-1.48.0.tgz",
+      "integrity": "sha512-rc4KZZsydQMpsFb10AM0pO9+f0mTTeEYB8x7qeCDPjVGbUjCCLc2cfwhO6yN5LuS+iQeJE8oVrUjUfXbDcGQcQ==",
       "license": "MIT",
       "dependencies": {
         "@elephant-xyz/fact-sheet": "^1.2.3",
@@ -7286,7 +7286,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.879.0",
         "@aws-sdk/client-s3": "^3.879.0",
-        "@elephant-xyz/cli": "^1.46.5",
+        "@elephant-xyz/cli": "^1.48.0",
         "adm-zip": "^0.5.10"
       },
       "devDependencies": {

--- a/prepare/lambdas/downloader/index.mjs
+++ b/prepare/lambdas/downloader/index.mjs
@@ -625,6 +625,55 @@ export const handler = async (event) => {
       );
     }
 
+    // Check for browser flow file in S3 (county-specific)
+    const environmentBucket = process.env.ENVIRONMENT_BUCKET;
+    if (environmentBucket && countyName) {
+      const browserFlowS3Key = `browser-flows/${countyName}.json`;
+
+      try {
+        console.log(
+          `Checking for browser flow file: s3://${environmentBucket}/${browserFlowS3Key}`,
+        );
+
+        const browserFlowResp = await s3.send(
+          new GetObjectCommand({
+            Bucket: environmentBucket,
+            Key: browserFlowS3Key,
+          }),
+        );
+
+        const browserFlowBytes =
+          await browserFlowResp.Body?.transformToByteArray();
+        if (!browserFlowBytes) {
+          throw new Error("Failed to download browser flow file body");
+        }
+
+        const browserFlowFilePath = path.join(tempDir, "browser-flow.json");
+        await fs.writeFile(
+          browserFlowFilePath,
+          Buffer.from(browserFlowBytes),
+        );
+        prepareOptions.browserFlowFile = browserFlowFilePath;
+        console.log(
+          `✓ Browser flow file downloaded and set for county ${countyName}: ${browserFlowFilePath}`,
+        );
+      } catch (downloadError) {
+        // File not found or other error - this is not critical, just log it
+        if (
+          downloadError instanceof Error &&
+          downloadError.name === "NoSuchKey"
+        ) {
+          console.log(
+            `No browser flow file found for county ${countyName}, continuing without it`,
+          );
+        } else {
+          console.error(
+            `Failed to download browser flow file for county ${countyName}: ${downloadError instanceof Error ? downloadError.message : String(downloadError)}`,
+          );
+        }
+      }
+    }
+
     // Handle browser flow template configuration with county-specific lookup
     const browserFlowTemplate = getEnvWithCountyFallback(
       "ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE",

--- a/prepare/lambdas/downloader/index.mjs
+++ b/prepare/lambdas/downloader/index.mjs
@@ -649,10 +649,7 @@ export const handler = async (event) => {
         }
 
         const browserFlowFilePath = path.join(tempDir, "browser-flow.json");
-        await fs.writeFile(
-          browserFlowFilePath,
-          Buffer.from(browserFlowBytes),
-        );
+        await fs.writeFile(browserFlowFilePath, Buffer.from(browserFlowBytes));
         prepareOptions.browserFlowFile = browserFlowFilePath;
         console.log(
           `✓ Browser flow file downloaded and set for county ${countyName}: ${browserFlowFilePath}`,

--- a/prepare/lambdas/downloader/package.json
+++ b/prepare/lambdas/downloader/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.879.0",
     "@aws-sdk/client-s3": "^3.879.0",
-    "@elephant-xyz/cli": "^1.46.5",
+    "@elephant-xyz/cli": "^1.48.0",
     "adm-zip": "^0.5.10"
   },
   "devDependencies": {

--- a/prepare/template.yaml
+++ b/prepare/template.yaml
@@ -217,6 +217,7 @@ Resources:
           ELEPHANT_PREPARE_CONTINUE_BUTTON: !Ref ElephantPrepareContinueButton
           ELEPHANT_PREPARE_BROWSER_FLOW_TEMPLATE: !Ref ElephantPrepareBrowserFlowTemplate
           ELEPHANT_PREPARE_BROWSER_FLOW_PARAMETERS: !Ref ElephantPrepareBrowserFlowParameters
+          ENVIRONMENT_BUCKET: !Ref EnvironmentBucket
           PROXY_ROTATION_TABLE_NAME: !Ref ProxyRotationTable
       Policies:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole


### PR DESCRIPTION
feat: add support for county-specific browser flows and update CLI dependency to version 1.48.0

- Introduced functionality to upload and utilize county-specific browser flow JSON files during deployment.
- Updated `@elephant-xyz/cli` dependency to version 1.48.0 across relevant files.
- Enhanced the downloader function to check for and download browser flow files from S3.
- Updated README to include instructions for adding browser flow files.