### PR TITLE
feat(workflow): add county-specific queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,11 @@ Tip: during local testing, remove `/tmp/county-transforms` to force a fresh down
 Use your input S3 bucket name:
 
 ```bash
+# Use default workflow queue
 ./scripts/start-step-function.sh <your-bucket-name>
+
+# Use county-specific queue
+./scripts/start-step-function.sh --queue elephant-workflow-queue-escambia <your-bucket-name>
 ```
 
 Available bucket names as of now:
@@ -388,6 +392,176 @@ Available bucket names as of now:
 - elephant-input-pinellas-county
 - elephant-input-polk-county
 - elephant-input-santa-county
+
+### County-Specific Queue Setup
+
+For better isolation and control, you can create separate queues for different counties. This allows you to:
+
+- Set different concurrency limits per county
+- Monitor county-specific processing separately
+- Isolate failures to individual counties
+- Process multiple counties in parallel with independent rate controls
+
+#### Creating a County-Specific Queue
+
+Use the `create-county-queue.sh` script to provision a complete queue setup:
+
+```bash
+./scripts/create-county-queue.sh <county-name>
+```
+
+**Example: Create queue for Escambia County**
+
+```bash
+./scripts/create-county-queue.sh escambia
+```
+
+**With custom concurrency (default: 100):**
+
+```bash
+MAX_CONCURRENCY=50 ./scripts/create-county-queue.sh escambia
+```
+
+**What the script does:**
+
+1. Creates Dead Letter Queue: `elephant-workflow-queue-escambia-dlq`
+   - MessageRetentionPeriod: 1209600 seconds (14 days)
+   - VisibilityTimeout: 331 seconds
+   - SSE encryption enabled
+
+2. Creates Main Queue: `elephant-workflow-queue-escambia`
+   - MessageRetentionPeriod: 1209600 seconds (14 days)
+   - VisibilityTimeout: 331 seconds
+   - SSE encryption enabled
+   - RedrivePolicy configured with maxReceiveCount: 3
+
+3. Configures Lambda Event Source Mapping
+   - Links queue to WorkflowStarterFunction
+   - BatchSize: 1 (one message per invocation)
+   - MaximumBatchingWindowInSeconds: 0 (process immediately)
+   - MaximumConcurrency: 100 (or custom value)
+
+**Script output example:**
+
+```
+[INFO] Creating county-specific workflow queue for: escambia
+[INFO] Stack name: elephant-oracle-node
+[INFO] Region: us-east-1
+[STEP] Creating Dead Letter Queue: elephant-workflow-queue-escambia-dlq
+[INFO] DLQ created: https://sqs.us-east-1.amazonaws.com/123456789012/elephant-workflow-queue-escambia-dlq
+[INFO] DLQ ARN: arn:aws:sqs:us-east-1:123456789012:elephant-workflow-queue-escambia-dlq
+[STEP] Creating workflow queue: elephant-workflow-queue-escambia
+[INFO] Queue created: https://sqs.us-east-1.amazonaws.com/123456789012/elephant-workflow-queue-escambia
+[INFO] Queue ARN: arn:aws:sqs:us-east-1:123456789012:elephant-workflow-queue-escambia
+[STEP] Getting WorkflowStarterFunction ARN from stack: elephant-oracle-node
+[INFO] Lambda Function ARN: arn:aws:lambda:us-east-1:123456789012:function:elephant-oracle-node-WorkflowStarterFunction-ABC123
+[STEP] Creating event source mapping between queue and Lambda function
+[INFO] Event source mapping created: 12345678-1234-1234-1234-123456789012
+
+[STEP] ✓ County queue setup completed successfully!
+
+[INFO] Summary:
+  County Name:              escambia
+  Queue Name:               elephant-workflow-queue-escambia
+  Queue URL:                https://sqs.us-east-1.amazonaws.com/123456789012/elephant-workflow-queue-escambia
+  Queue ARN:                arn:aws:sqs:us-east-1:123456789012:elephant-workflow-queue-escambia
+  DLQ Name:                 elephant-workflow-queue-escambia-dlq
+  DLQ URL:                  https://sqs.us-east-1.amazonaws.com/123456789012/elephant-workflow-queue-escambia-dlq
+  DLQ ARN:                  arn:aws:sqs:us-east-1:123456789012:elephant-workflow-queue-escambia-dlq
+  Lambda Function ARN:      arn:aws:lambda:us-east-1:123456789012:function:elephant-oracle-node-WorkflowStarterFunction-ABC123
+  Event Source Mapping:     12345678-1234-1234-1234-123456789012
+  Max Concurrency:          100
+
+[INFO] You can now send messages to: https://sqs.us-east-1.amazonaws.com/123456789012/elephant-workflow-queue-escambia
+```
+
+#### Using County-Specific Queues
+
+**Process data through county-specific queue:**
+
+```bash
+# Start S3ToSqsStateMachine and populate the county-specific queue
+./scripts/start-step-function.sh --queue elephant-workflow-queue-escambia elephant-input-escambia-county
+```
+
+**Multiple counties example:**
+
+```bash
+# Create queues for multiple counties
+./scripts/create-county-queue.sh escambia
+./scripts/create-county-queue.sh broward
+MAX_CONCURRENCY=200 ./scripts/create-county-queue.sh miami-dade  # Higher volume county
+
+# Process each county with their dedicated queue
+./scripts/start-step-function.sh --queue elephant-workflow-queue-escambia elephant-input-escambia-county
+./scripts/start-step-function.sh --queue elephant-workflow-queue-broward elephant-input-broward-county
+./scripts/start-step-function.sh --queue elephant-workflow-queue-miami-dade elephant-input-miami-dade-county
+```
+
+#### How It Works
+
+1. **S3ToSqsStateMachine** lists S3 objects and sends messages to the specified queue
+2. **WorkflowStarterFunction** is triggered by the county-specific queue via event source mapping
+3. **ElephantExpressWorkflow** executes synchronously
+4. **On failure**, the message is automatically retried by SQS (maxReceiveCount: 3)
+5. **After 3 failures**, the message moves to the county-specific DLQ automatically
+
+#### Error Handling
+
+- The state machine no longer manually requeues to DLQ
+- SQS event source mapping handles all retries and DLQ delivery
+- WorkflowStarterFunction throws errors on failure to trigger redelivery
+- Messages are only moved to DLQ after exhausting all retries
+- Each county's failures are isolated in its own DLQ
+
+#### Monitoring County Queues
+
+**Check queue depth:**
+
+```bash
+aws sqs get-queue-attributes \
+  --queue-url $(aws sqs get-queue-url --queue-name elephant-workflow-queue-escambia --query 'QueueUrl' --output text) \
+  --attribute-names ApproximateNumberOfMessages,ApproximateNumberOfMessagesNotVisible
+```
+
+**Check DLQ depth:**
+
+```bash
+aws sqs get-queue-attributes \
+  --queue-url $(aws sqs get-queue-url --queue-name elephant-workflow-queue-escambia-dlq --query 'QueueUrl' --output text) \
+  --attribute-names ApproximateNumberOfMessages
+```
+
+**View event source mapping status:**
+
+```bash
+aws lambda list-event-source-mappings \
+  --function-name $(aws cloudformation describe-stack-resources \
+    --stack-name elephant-oracle-node \
+    --query "StackResources[?LogicalResourceId=='WorkflowStarterFunction'].PhysicalResourceId" \
+    --output text) \
+  --query "EventSourceMappings[?contains(EventSourceArn, 'elephant-workflow-queue-escambia')]"
+```
+
+#### Adjusting Concurrency
+
+To change the concurrency for an existing queue, update the event source mapping:
+
+```bash
+# Get the event source mapping UUID
+UUID=$(aws lambda list-event-source-mappings \
+  --function-name $(aws cloudformation describe-stack-resources \
+    --stack-name elephant-oracle-node \
+    --query "StackResources[?LogicalResourceId=='WorkflowStarterFunction'].PhysicalResourceId" \
+    --output text) \
+  --query "EventSourceMappings[?contains(EventSourceArn, 'elephant-workflow-queue-escambia')].UUID" \
+  --output text)
+
+# Update the maximum concurrency
+aws lambda update-event-source-mapping \
+  --uuid $UUID \
+  --scaling-config "MaximumConcurrency=50"
+```
 
 ### 4) Pause your Airflow DAG
 
@@ -589,10 +763,26 @@ When messages fail processing multiple times, they are moved to Dead Letter Queu
 ./scripts/reprocess-dlq.sh --dlq-type transactions --max-messages 1000
 ```
 
+**Reprocess County-Specific DLQ messages:**
+
+County-specific queues have their own DLQs. To reprocess failed messages from a county-specific DLQ:
+
+```bash
+# Get the DLQ URL for the county
+DLQ_URL=$(aws sqs get-queue-url --queue-name elephant-workflow-queue-escambia-dlq --query 'QueueUrl' --output text)
+TARGET_URL=$(aws sqs get-queue-url --queue-name elephant-workflow-queue-escambia --query 'QueueUrl' --output text)
+
+# Use AWS SQS redrive to move messages back
+aws sqs start-message-move-task \
+  --source-arn $(aws sqs get-queue-attributes --queue-url $DLQ_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text) \
+  --destination-arn $(aws sqs get-queue-attributes --queue-url $TARGET_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
+```
+
 **DLQ Types:**
 
 - `workflow` - Workflow Dead Letter Queue → Workflow SQS Queue
 - `transactions` - Transactions Dead Letter Queue → Transactions SQS Queue
+- County-specific: `elephant-workflow-queue-<county>-dlq` → `elephant-workflow-queue-<county>`
 
 **Parameters:**
 
@@ -601,6 +791,10 @@ When messages fail processing multiple times, they are moved to Dead Letter Queu
 - `--max-messages` - Maximum messages to reprocess (default: 100)
 - `--verbose` - Detailed output
 
-```
+**Error Handling Changes:**
 
-```
+As of the latest update, the system uses SQS-native error handling:
+- Messages are automatically retried by SQS (maxReceiveCount: 3)
+- Failed messages move to DLQ automatically after exhausting retries
+- No manual requeuing logic in the state machine
+- WorkflowStarterFunction throws errors to trigger SQS redelivery

--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ aws sqs start-message-move-task \
 **Error Handling Changes:**
 
 As of the latest update, the system uses SQS-native error handling:
+
 - Messages are automatically retried by SQS (maxReceiveCount: 3)
 - Failed messages move to DLQ automatically after exhausting retries
 - No manual requeuing logic in the state machine

--- a/prepare/template.yaml
+++ b/prepare/template.yaml
@@ -518,8 +518,6 @@ Resources:
         WorkflowPreProcessorFunction: !GetAtt WorkflowPreProcessorFunction.Arn
         DownloaderFunction: !GetAtt DownloaderFunction.Arn
         WorkflowPostProcessorFunction: !GetAtt WorkflowPostProcessorFunction.Arn
-        WorkflowSqsQueueUrl: !Ref WorkflowSqsQueue
-        WorkflowDeadLetterQueueUrl: !Ref WorkflowDeadLetterQueue
         TransactionsSqsQueueUrl: !Ref TransactionsSqsQueue
       Role: !GetAtt ElephantExpressStateMachineRole.Arn
       Logging:
@@ -564,8 +562,6 @@ Resources:
                 Action:
                   - sqs:SendMessage
                 Resource:
-                  - !GetAtt WorkflowSqsQueue.Arn
-                  - !GetAtt WorkflowDeadLetterQueue.Arn
                   - !GetAtt TransactionsSqsQueue.Arn
               - Effect: Allow
                 Action:
@@ -617,6 +613,8 @@ Resources:
                 Resource:
                   - !GetAtt MwaaSqsQueue.Arn
                   - !GetAtt WorkflowSqsQueue.Arn
+                  # Allow sending to county-specific queues (elephant-workflow-queue-*)
+                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:elephant-workflow-queue-*"
               - Effect: Allow
                 Action:
                   - states:StartExecution

--- a/scripts/create-county-queue.sh
+++ b/scripts/create-county-queue.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create county-specific workflow queue with DLQ and Lambda trigger
+# Usage: ./create-county-queue.sh <county_name>
+# Example: ./create-county-queue.sh escambia
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+err()  { echo -e "${RED}[ERROR]${NC} $*"; }
+step() { echo -e "${BLUE}[STEP]${NC} $*"; }
+
+# Validate input
+if [ $# -eq 0 ]; then
+    err "County name is required"
+    echo "Usage: $0 <county_name>"
+    echo "Example: $0 escambia"
+    exit 1
+fi
+
+COUNTY_NAME="$1"
+STACK_NAME="${STACK_NAME:-elephant-oracle-node}"
+REGION="${AWS_REGION:-us-east-1}"
+
+# Queue configuration (matching template.yaml)
+VISIBILITY_TIMEOUT=331
+MESSAGE_RETENTION_PERIOD=1209600
+MAX_RECEIVE_COUNT=3
+BATCH_SIZE=1
+BATCHING_WINDOW=0
+MAX_CONCURRENCY="${MAX_CONCURRENCY:-100}"
+
+# Queue names
+DLQ_NAME="elephant-workflow-queue-${COUNTY_NAME}-dlq"
+QUEUE_NAME="elephant-workflow-queue-${COUNTY_NAME}"
+
+info "Creating county-specific workflow queue for: $COUNTY_NAME"
+info "Stack name: $STACK_NAME"
+info "Region: $REGION"
+
+# Step 1: Create Dead Letter Queue
+step "Creating Dead Letter Queue: $DLQ_NAME"
+DLQ_URL=$(aws sqs create-queue \
+    --queue-name "$DLQ_NAME" \
+    --attributes "{
+        \"MessageRetentionPeriod\": \"$MESSAGE_RETENTION_PERIOD\",
+        \"VisibilityTimeout\": \"$VISIBILITY_TIMEOUT\",
+        \"SqsManagedSseEnabled\": \"true\"
+    }" \
+    --region "$REGION" \
+    --query 'QueueUrl' \
+    --output text)
+
+if [ -z "$DLQ_URL" ]; then
+    err "Failed to create Dead Letter Queue"
+    exit 1
+fi
+
+info "DLQ created: $DLQ_URL"
+
+# Get DLQ ARN
+DLQ_ARN=$(aws sqs get-queue-attributes \
+    --queue-url "$DLQ_URL" \
+    --attribute-names QueueArn \
+    --region "$REGION" \
+    --query 'Attributes.QueueArn' \
+    --output text)
+
+info "DLQ ARN: $DLQ_ARN"
+
+# Step 2: Create main workflow queue with redrive policy
+step "Creating workflow queue: $QUEUE_NAME"
+
+# Build redrive policy JSON
+REDRIVE_POLICY="{\"deadLetterTargetArn\":\"${DLQ_ARN}\",\"maxReceiveCount\":${MAX_RECEIVE_COUNT}}"
+
+QUEUE_URL=$(aws sqs create-queue \
+    --queue-name "$QUEUE_NAME" \
+    --attributes "{
+        \"VisibilityTimeout\": \"$VISIBILITY_TIMEOUT\",
+        \"MessageRetentionPeriod\": \"$MESSAGE_RETENTION_PERIOD\",
+        \"SqsManagedSseEnabled\": \"true\",
+        \"RedrivePolicy\": $(echo "$REDRIVE_POLICY" | jq -R .)
+    }" \
+    --region "$REGION" \
+    --query 'QueueUrl' \
+    --output text)
+
+if [ -z "$QUEUE_URL" ]; then
+    err "Failed to create workflow queue"
+    exit 1
+fi
+
+info "Queue created: $QUEUE_URL"
+
+# Get Queue ARN
+QUEUE_ARN=$(aws sqs get-queue-attributes \
+    --queue-url "$QUEUE_URL" \
+    --attribute-names QueueArn \
+    --region "$REGION" \
+    --query 'Attributes.QueueArn' \
+    --output text)
+
+info "Queue ARN: $QUEUE_ARN"
+
+# Step 3: Get WorkflowStarterFunction ARN from CloudFormation stack
+step "Getting WorkflowStarterFunction ARN from stack: $STACK_NAME"
+
+FUNCTION_ARN=$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='WorkflowStarterFunctionArn'].OutputValue" \
+    --output text 2>/dev/null || true)
+
+if [ -z "$FUNCTION_ARN" ]; then
+    warn "WorkflowStarterFunctionArn not found in stack outputs, trying to get function directly"
+
+    # Try to get function name from stack resources
+    FUNCTION_NAME=$(aws cloudformation describe-stack-resources \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION" \
+        --query "StackResources[?LogicalResourceId=='WorkflowStarterFunction'].PhysicalResourceId" \
+        --output text)
+
+    if [ -z "$FUNCTION_NAME" ]; then
+        err "Failed to find WorkflowStarterFunction in stack"
+        exit 1
+    fi
+
+    FUNCTION_ARN=$(aws lambda get-function \
+        --function-name "$FUNCTION_NAME" \
+        --region "$REGION" \
+        --query 'Configuration.FunctionArn' \
+        --output text)
+fi
+
+if [ -z "$FUNCTION_ARN" ]; then
+    err "Failed to get WorkflowStarterFunction ARN"
+    exit 1
+fi
+
+info "Lambda Function ARN: $FUNCTION_ARN"
+
+# Step 4: Create event source mapping
+step "Creating event source mapping between queue and Lambda function"
+
+EVENT_SOURCE_UUID=$(aws lambda create-event-source-mapping \
+    --function-name "$FUNCTION_ARN" \
+    --event-source-arn "$QUEUE_ARN" \
+    --batch-size "$BATCH_SIZE" \
+    --maximum-batching-window-in-seconds "$BATCHING_WINDOW" \
+    --scaling-config "MaximumConcurrency=$MAX_CONCURRENCY" \
+    --region "$REGION" \
+    --query 'UUID' \
+    --output text)
+
+if [ -z "$EVENT_SOURCE_UUID" ]; then
+    err "Failed to create event source mapping"
+    exit 1
+fi
+
+info "Event source mapping created: $EVENT_SOURCE_UUID"
+
+# Summary
+echo ""
+step "✓ County queue setup completed successfully!"
+echo ""
+info "Summary:"
+echo "  County Name:              $COUNTY_NAME"
+echo "  Queue Name:               $QUEUE_NAME"
+echo "  Queue URL:                $QUEUE_URL"
+echo "  Queue ARN:                $QUEUE_ARN"
+echo "  DLQ Name:                 $DLQ_NAME"
+echo "  DLQ URL:                  $DLQ_URL"
+echo "  DLQ ARN:                  $DLQ_ARN"
+echo "  Lambda Function ARN:      $FUNCTION_ARN"
+echo "  Event Source Mapping:     $EVENT_SOURCE_UUID"
+echo "  Max Concurrency:          $MAX_CONCURRENCY"
+echo ""
+info "You can now send messages to: $QUEUE_URL"
+echo ""

--- a/workflow/lambdas/starter/index.mjs
+++ b/workflow/lambdas/starter/index.mjs
@@ -55,7 +55,7 @@ export const handler = async (event) => {
     const executionArn = resp.executionArn || "arn not found";
 
     // Check if the step function execution failed
-    if (resp.status === "FAILED" || resp.status === "TIMED_OUT" || resp.status === "ABORTED") {
+    if (resp.status === "FAILED" || resp.status === "TIMED_OUT") {
       console.error(
         JSON.stringify({
           ...logBase,
@@ -69,7 +69,7 @@ export const handler = async (event) => {
       );
       // Throw error to trigger SQS redelivery to DLQ
       throw new Error(
-        `Step function execution failed with status: ${resp.status}. Cause: ${resp.cause || "N/A"}`
+        `Step function execution failed with status: ${resp.status}. Cause: ${resp.cause || "N/A"}`,
       );
     }
 

--- a/workflow/state-machines/elephant-express.asl.yaml
+++ b/workflow/state-machines/elephant-express.asl.yaml
@@ -27,7 +27,7 @@ States:
     Catch:
       - ErrorEquals: [States.ALL]
         ResultPath: $.error
-        Next: RequeueOnFailure
+        Next: FailRuntime
 
   Prepare:
     Type: Task
@@ -55,7 +55,7 @@ States:
     Catch:
       - ErrorEquals: [States.ALL]
         ResultPath: $.error
-        Next: RequeueOnFailure
+        Next: FailRuntime
 
   Postprocess:
     Type: Task
@@ -83,7 +83,7 @@ States:
     Catch:
       - ErrorEquals: [States.ALL]
         ResultPath: $.error
-        Next: RequeueOnFailure
+        Next: FailRuntime
 
   QueueForTheSubmit:
     Type: Task
@@ -93,17 +93,6 @@ States:
       MessageBody.$: "States.JsonToString($.post.items)"
     ResultPath: null
     End: true
-
-  # RequeueOnSuccess removed to prevent requeue on successful completion
-
-  RequeueOnFailure:
-    Type: Task
-    Resource: arn:aws:states:::sqs:sendMessage
-    Parameters:
-      QueueUrl: ${WorkflowDeadLetterQueueUrl}
-      MessageBody.$: "States.JsonToString($.message)"
-    ResultPath: null
-    Next: FailRuntime
 
   FailRuntime:
     Type: Fail


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce county-specific workflow queues with provisioning and selection support, update workflow/starter to rely on SQS retries/DLQs, and adjust IAM/templating and docs accordingly.
> 
> - **Workflow/Runtime**:
>   - **State Machine**: Remove manual DLQ requeue; `Catch` paths now go to `FailRuntime` (no SQS send), relying on SQS-native redrive. Drop `WorkflowSqsQueueUrl`/`WorkflowDeadLetterQueueUrl` substitutions.
>   - **Starter Lambda**: On `FAILED`/`TIMED_OUT` executions, throw errors to trigger SQS redelivery; no longer always ack success.
> - **Infrastructure/IAM**:
>   - **Template**: Remove SQS send permissions to `WorkflowSqsQueue` and its DLQ from `ElephantExpressStateMachineRole`. Expand `StepFunctionRole` to allow `sqs:SendMessage` to `elephant-workflow-queue-*` and resolve queue URLs.
> - **Scripts/CLI**:
>   - **New** `scripts/create-county-queue.sh`: Provisions `elephant-workflow-queue-<county>` plus DLQ and Lambda event source mapping with configurable `MaximumConcurrency`.
>   - **Enhanced** `scripts/start-step-function.sh`: Add `--queue` to target a specific queue (name or URL); resolve queue URL before starting `S3ToSqsStateMachine`.
> - **Docs**:
>   - **README**: Add county-specific queue setup/usage, monitoring, concurrency tuning, and DLQ reprocessing guidance; document SQS-native error handling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e49e7e642268310093ea264abe81d18173e3d6f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->