### PR TITLE
Default workflow to structured archive branch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,83 @@
+# Oracle Node Workflow Context
+
+This context describes the workflow language used to process county source data into either archived structured scrape artifacts or mintable data outputs.
+
+## Language
+
+**Structured Archive**:
+The default workflow branch that transforms county source data and stores structured scrape artifacts in Amazon S3.
+_Avoid_: current flow, S3 upload flow, scraped data flow
+
+**Structured Archive Artifact**:
+The transformed output ZIP stored by the **Structured Archive** branch as the branch's primary S3 artifact.
+_Avoid_: normalized JSON, extracted files, validation output
+
+**Transform Artifact**:
+The transformed output ZIP produced immediately after county transformation.
+_Avoid_: structured copy, archive copy
+
+**Minting**:
+The explicit workflow branch that transforms county source data and continues through schema validation, hash generation, IPFS upload, and submit.
+_Avoid_: current flow, hash/upload flow, validate flow
+
+**Workflow Branch**:
+The execution input selection that determines whether the workflow runs **Structured Archive** or **Minting** after transformation.
+_Avoid_: mode, mint flag, flow type
+
+**Workflow Branch Flag**:
+The operator-facing start option that supplies the **Workflow Branch** value.
+_Avoid_: minting flag, mode flag
+
+## Relationships
+
+- A workflow execution chooses exactly one branch: **Structured Archive** or **Minting**.
+- A missing **Workflow Branch** means **Structured Archive**.
+- The effective **Workflow Branch** is normalized into workflow state before transformation.
+- An unrecognized **Workflow Branch** is an invalid execution input, not a request for the default branch.
+- An invalid **Workflow Branch** fails before transformation begins.
+- Every caller that omits the **Workflow Branch** runs **Structured Archive**, including callers that previously expected **Minting**.
+- S3-triggered executions run **Structured Archive** unless a controlled direct caller explicitly supplies the **Minting** branch.
+- Operator tooling exposes a **Workflow Branch Flag** for explicit branch selection.
+- **Structured Archive** does not perform the **Minting** branch's schema validation, hash generation, IPFS upload, or submit steps.
+- A **Structured Archive** execution uses the **Transform Artifact** as its **Structured Archive Artifact**.
+- A **Structured Archive** execution exposes its artifact through the existing transform result rather than a branch-specific result alias.
+- A **Structured Archive** execution emits a branch-level success event after transformation completes.
+
+## Example dialogue
+
+> **Dev:** "Should this execution run **Minting** after Transform?"
+> **Domain expert:** "No — unless the caller explicitly asks for **Minting**, use **Structured Archive** and save the transformed scrape artifacts to S3."
+
+> **Dev:** "Should the **Structured Archive Artifact** be normalized JSON?"
+> **Domain expert:** "No — for the first version, archive the transformed output ZIP only."
+
+> **Dev:** "Should **Structured Archive** copy the ZIP to a new S3 prefix?"
+> **Domain expert:** "No — reuse the **Transform Artifact** URI as the archive artifact."
+
+> **Dev:** "What happens if `workflowBranch` is omitted?"
+> **Domain expert:** "Treat it as **Structured Archive**; only `minting` explicitly runs the **Minting** branch."
+
+> **Dev:** "Should omitted `workflowBranch` stay absent in execution state?"
+> **Domain expert:** "No — normalize the effective branch to `structured_archive` before transformation."
+
+> **Dev:** "When should an invalid `workflowBranch` fail?"
+> **Domain expert:** "Before transformation starts; invalid inputs should not produce transform artifacts."
+
+> **Dev:** "Can an S3 object upload request **Minting** by default?"
+> **Domain expert:** "No — S3-triggered executions archive by default; **Minting** requires a controlled direct caller."
+
+> **Dev:** "Should direct submit tooling preserve **Minting** automatically?"
+> **Domain expert:** "No — all callers share the same default; they must request `minting` explicitly."
+
+> **Dev:** "How should an operator request **Minting** from start tooling?"
+> **Domain expert:** "Use the **Workflow Branch Flag** with `minting`; do not use a separate minting-specific flag."
+
+> **Dev:** "Should the final output add `structuredArchive.artifactS3Uri`?"
+> **Domain expert:** "No — the first version uses the existing transform result as the output contract."
+
+> **Dev:** "How do operators know a default execution intentionally ended after Transform?"
+> **Domain expert:** "Look for the **Structured Archive** success event after the Transform success event."
+
+## Flagged ambiguities
+
+- "upload" was used for both IPFS upload and S3 persistence — resolved: **Minting** uses IPFS upload, while **Structured Archive** stores artifacts in S3.

--- a/docs/adr/0001-default-workflow-branch-is-structured-archive.md
+++ b/docs/adr/0001-default-workflow-branch-is-structured-archive.md
@@ -1,0 +1,12 @@
+# Default workflow branch is Structured Archive
+
+The workflow defaults to the **Structured Archive** branch: after Transform succeeds, an execution archives by reusing the existing transformed output ZIP in S3 and emits a Structured Archive success event. **Minting** remains available only when any caller explicitly supplies `workflowBranch: "minting"`; this makes every omitted branch value safe by default while preserving the existing Transform → SVL → Hash → IPFS Upload → Submit path for intentional minting runs.
+
+## Consequences
+
+- Missing `workflowBranch` means `structured_archive`, and the effective value is normalized into workflow state before transformation.
+- Invalid `workflowBranch` values fail before transformation begins instead of silently defaulting or producing artifacts.
+- The branch point is after Transform because both branches share the same transform output.
+- Structured Archive does not create a second S3 copy or a branch-specific output alias in the first version.
+
+- All callers share the same default: omitted `workflowBranch` runs Structured Archive, including tooling that previously assumed Minting.

--- a/scripts/start-step-function.sh
+++ b/scripts/start-step-function.sh
@@ -25,6 +25,9 @@ Options:
     --express          Directly invoke ElephantExpressWorkflow (bypasses S3ToSqsStateMachine)
     --queue <name>     Send message to specific queue (default: elephant-workflow-queue)
                        Can be queue name (e.g., elephant-workflow-queue-escambia) or URL
+    --workflow-branch <branch>
+                       Workflow branch to run: structured_archive or minting
+                       Defaults to omitted, which the workflow treats as structured_archive
     --help             Show this help message
 
 Environment Variables:
@@ -40,9 +43,21 @@ Examples:
     # Start ElephantExpressWorkflow directly with specific S3 object
     $0 --express my-data-bucket source-data/county-data.json
 
+    # Explicitly run the Minting branch
+    $0 --workflow-branch minting --express my-data-bucket source-data/county-data.json
+
     # Start ElephantExpressWorkflow with auto-generated S3 object key
     $0 --express my-data-bucket
 EOF
+}
+
+validate_workflow_branch() {
+    local workflow_branch="$1"
+    if [[ -n "$workflow_branch" && "$workflow_branch" != "structured_archive" && "$workflow_branch" != "minting" ]]; then
+        err "Invalid workflow branch: $workflow_branch"
+        err "Workflow branch must be one of: structured_archive, minting"
+        exit 1
+    fi
 }
 
 # Check prerequisites
@@ -114,6 +129,7 @@ start_execution() {
     local bucket_name="$1"
     local step_function_arn="$2"
     local sqs_queue_url="$3"
+    local workflow_branch="$4"
     
     # Generate unique execution name with timestamp and bucket name
     local timestamp=$(date +%Y%m%d-%H%M%S)
@@ -126,10 +142,18 @@ start_execution() {
 
     # Create execution input
     local input_payload
-    input_payload=$(jq -n \
-        --arg bucket "$bucket_name" \
-        --arg sqs_url "$sqs_queue_url" \
-        '{bucketName: $bucket, sqsQueueUrl: $sqs_url}')
+    if [[ -n "$workflow_branch" ]]; then
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg sqs_url "$sqs_queue_url" \
+            --arg workflow_branch "$workflow_branch" \
+            '{bucketName: $bucket, sqsQueueUrl: $sqs_url, workflowBranch: $workflow_branch}')
+    else
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg sqs_url "$sqs_queue_url" \
+            '{bucketName: $bucket, sqsQueueUrl: $sqs_url}')
+    fi
 
     # Start execution
     local execution_arn
@@ -172,6 +196,7 @@ start_express_workflow() {
     local bucket_name="$1"
     local s3_object_key="$2"
     local express_workflow_arn="$3"
+    local workflow_branch="$4"
     
     # Generate unique execution name with timestamp and bucket name
     local timestamp=$(date +%Y%m%d-%H%M%S)
@@ -184,17 +209,33 @@ start_express_workflow() {
 
     # Create S3 event record format for the workflow
     local input_payload
-    input_payload=$(jq -n \
-        --arg bucket "$bucket_name" \
-        --arg key "$s3_object_key" \
-        '{
-            Records: [{
-                s3: {
-                    bucket: { name: $bucket },
-                    object: { key: $key }
-                }
-            }]
-        }')
+    if [[ -n "$workflow_branch" ]]; then
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg key "$s3_object_key" \
+            --arg workflow_branch "$workflow_branch" \
+            '{
+                workflowBranch: $workflow_branch,
+                Records: [{
+                    s3: {
+                        bucket: { name: $bucket },
+                        object: { key: $key }
+                    }
+                }]
+            }')
+    else
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg key "$s3_object_key" \
+            '{
+                Records: [{
+                    s3: {
+                        bucket: { name: $bucket },
+                        object: { key: $key }
+                    }
+                }]
+            }')
+    fi
 
     # Start execution
     local execution_arn
@@ -236,6 +277,7 @@ start_express_workflow() {
     local bucket_name="$1"
     local s3_object_key="$2"
     local express_workflow_arn="$3"
+    local workflow_branch="$4"
     
     info "Directly invoking ElephantExpressWorkflow"
     info "S3 Bucket: $bucket_name"
@@ -249,17 +291,33 @@ start_express_workflow() {
 
     # Create S3 event record format for the workflow
     local input_payload
-    input_payload=$(jq -n \
-        --arg bucket "$bucket_name" \
-        --arg key "$s3_object_key" \
-        '{
-            Records: [{
-                s3: {
-                    bucket: { name: $bucket },
-                    object: { key: $key }
-                }
-            }]
-        }')
+    if [[ -n "$workflow_branch" ]]; then
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg key "$s3_object_key" \
+            --arg workflow_branch "$workflow_branch" \
+            '{
+                workflowBranch: $workflow_branch,
+                Records: [{
+                    s3: {
+                        bucket: { name: $bucket },
+                        object: { key: $key }
+                    }
+                }]
+            }')
+    else
+        input_payload=$(jq -n \
+            --arg bucket "$bucket_name" \
+            --arg key "$s3_object_key" \
+            '{
+                Records: [{
+                    s3: {
+                        bucket: { name: $bucket },
+                        object: { key: $key }
+                    }
+                }]
+            }')
+    fi
 
     info "Starting Express Step Function execution: $execution_name"
 
@@ -288,6 +346,7 @@ main() {
     local queue_name=""
     local bucket_name=""
     local s3_object_key=""
+    local workflow_branch=""
 
     # Parse command line arguments
     while [[ $# -gt 0 ]]; do
@@ -304,6 +363,16 @@ main() {
                     exit 1
                 fi
                 queue_name="$2"
+                shift 2
+                ;;
+            --workflow-branch)
+                if [[ -z "$2" || "$2" =~ ^-- ]]; then
+                    err "--workflow-branch requires a branch value"
+                    usage
+                    exit 1
+                fi
+                workflow_branch="$2"
+                validate_workflow_branch "$workflow_branch"
                 shift 2
                 ;;
             --help)
@@ -336,6 +405,8 @@ main() {
         usage
         exit 1
     fi
+
+    validate_workflow_branch "$workflow_branch"
 
     # Set default S3 object key if not provided
     if [[ -z "$s3_object_key" ]]; then
@@ -372,7 +443,7 @@ main() {
             exit 1
         fi
         info "Express mode: Directly invoking ElephantExpressWorkflow"
-        start_express_workflow "$bucket_name" "$s3_object_key" "$express_workflow_arn"
+        start_express_workflow "$bucket_name" "$s3_object_key" "$express_workflow_arn" "$workflow_branch"
     else
         # Determine target queue
         local sqs_queue_url
@@ -398,7 +469,7 @@ main() {
         fi
 
         info "Starting S3ToSqsStateMachine -> $sqs_queue_url"
-        start_execution "$bucket_name" "$step_function_arn" "$sqs_queue_url"
+        start_execution "$bucket_name" "$step_function_arn" "$sqs_queue_url" "$workflow_branch"
     fi
 }
 

--- a/tests/workflow/state-machines/elephant-express.test.mjs
+++ b/tests/workflow/state-machines/elephant-express.test.mjs
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "fs/promises";
+import { parse } from "yaml";
+
+/**
+ * Load the Elephant Express ASL definition through the same YAML document that
+ * deployment consumes.
+ *
+ * @returns {Promise<{
+ *   StartAt: string,
+ *   States: Record<string, {
+ *     Type: string,
+ *     Next?: string,
+ *     Default?: string,
+ *     Choices?: Array<Record<string, unknown>>,
+ *     Parameters?: Record<string, unknown>,
+ *   }>,
+ * }>} Parsed state machine definition.
+ */
+async function loadStateMachine() {
+  const source = await readFile(
+    new URL(
+      "../../../workflow/state-machines/elephant-express.asl.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+  return parse(source);
+}
+
+describe("Elephant Express workflow branch selection", () => {
+  it("validates and normalizes the Workflow Branch before other workflow work", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.StartAt).toBe("ValidateWorkflowBranch");
+    expect(definition.States.ValidateWorkflowBranch).toMatchObject({
+      Type: "Choice",
+      Default: "InvalidWorkflowBranch",
+    });
+    expect(definition.States.ValidateWorkflowBranch.Choices).toEqual(
+      expect.arrayContaining([
+        {
+          Variable: "$.workflowBranch",
+          IsPresent: false,
+          Next: "DefaultWorkflowBranch",
+        },
+        {
+          Variable: "$.workflowBranch",
+          StringEquals: "structured_archive",
+          Next: "CheckDirectSubmit",
+        },
+        {
+          Variable: "$.workflowBranch",
+          StringEquals: "minting",
+          Next: "CheckDirectSubmit",
+        },
+      ]),
+    );
+    expect(definition.States.DefaultWorkflowBranch).toMatchObject({
+      Type: "Pass",
+      Next: "CheckDirectSubmit",
+    });
+    expect(definition.States.InvalidWorkflowBranch).toMatchObject({
+      Type: "Fail",
+      Error: "InvalidWorkflowBranch",
+    });
+  });
+
+  it("routes the default post-transform branch to Structured Archive", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.States.EmitTransformSucceeded.Next).toBe(
+      "ChoosePostTransformBranch",
+    );
+    expect(definition.States.ChoosePostTransformBranch).toMatchObject({
+      Type: "Choice",
+      Default: "EmitStructuredArchiveSucceeded",
+    });
+  });
+
+  it("routes explicit Minting executions to the existing SVL path", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.States.ChoosePostTransformBranch.Choices).toContainEqual({
+      Variable: "$.workflowBranch",
+      StringEquals: "minting",
+      Next: "EmitSvlScheduled",
+    });
+  });
+
+  it("preserves the Workflow Branch when rebuilding state for prepare-skip checks", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.States.BuildHeadParams.Output).toContain(
+      '"workflowBranch": $states.input.workflowBranch',
+    );
+  });
+
+  it("emits a Structured Archive success event before completing default executions", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.States.EmitStructuredArchiveSucceeded).toMatchObject({
+      Type: "Task",
+      Resource: "arn:aws:states:::events:putEvents",
+      Parameters: {
+        Entries: [
+          {
+            Detail: {
+              status: "SUCCEEDED",
+              phase: "StructuredArchive",
+              step: "StructuredArchive",
+            },
+          },
+        ],
+      },
+      Next: "WorkflowComplete",
+    });
+  });
+});

--- a/tests/workflow/state-machines/elephant-express.test.mjs
+++ b/tests/workflow/state-machines/elephant-express.test.mjs
@@ -79,6 +79,19 @@ describe("Elephant Express workflow branch selection", () => {
     });
   });
 
+  it("falls through to the post-transform branch when EmitTransformSucceeded errors", async () => {
+    const definition = await loadStateMachine();
+
+    expect(definition.States.EmitTransformSucceeded.Catch).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ErrorEquals: ["States.ALL"],
+          Next: "ChoosePostTransformBranch",
+        }),
+      ]),
+    );
+  });
+
   it("routes explicit Minting executions to the existing SVL path", async () => {
     const definition = await loadStateMachine();
 

--- a/workflow/state-machines/elephant-express.asl.yaml
+++ b/workflow/state-machines/elephant-express.asl.yaml
@@ -1,6 +1,33 @@
 Comment: Elephant Express workflow. Triggered by Starter Lambda with one SQS message payload.
-StartAt: CheckDirectSubmit
+StartAt: ValidateWorkflowBranch
 States:
+  ValidateWorkflowBranch:
+    Type: Choice
+    Comment: "Validate Workflow Branch before starting workflow work"
+    Choices:
+      - Variable: $.workflowBranch
+        IsPresent: false
+        Next: DefaultWorkflowBranch
+      - Variable: $.workflowBranch
+        StringEquals: structured_archive
+        Next: CheckDirectSubmit
+      - Variable: $.workflowBranch
+        StringEquals: minting
+        Next: CheckDirectSubmit
+    Default: InvalidWorkflowBranch
+
+  DefaultWorkflowBranch:
+    Type: Pass
+    QueryLanguage: JSONata
+    Comment: "Default omitted Workflow Branch to Structured Archive"
+    Output: "{% $merge([$states.input, { 'workflowBranch': 'structured_archive' }]) %}"
+    Next: CheckDirectSubmit
+
+  InvalidWorkflowBranch:
+    Type: Fail
+    Error: InvalidWorkflowBranch
+    Cause: "workflowBranch must be structured_archive or minting"
+
   CheckDirectSubmit:
     Type: Choice
     Comment: "Check if this is a direct-submit execution (transactionItems provided in message)"
@@ -130,7 +157,8 @@ States:
             "expectedOutputUri": $states.input.pre.output_prefix & '/output.zip'
           },
           "message": $states.input.message,
-          "pre": $states.input.pre
+          "pre": $states.input.pre,
+          "workflowBranch": $states.input.workflowBranch
         }
       %}
     Next: HeadOutputZip
@@ -403,11 +431,42 @@ States:
             step: Transform
             dataGroupLabel: County
     ResultPath: $.eventResult
-    Next: EmitSvlScheduled
+    Next: ChoosePostTransformBranch
     Catch:
       - ErrorEquals: [States.ALL]
         ResultPath: $.eventError
+        Next: ChoosePostTransformBranch
+
+  ChoosePostTransformBranch:
+    Type: Choice
+    Comment: "Choose Structured Archive by default, or Minting when explicitly requested"
+    Choices:
+      - Variable: $.workflowBranch
+        StringEquals: minting
         Next: EmitSvlScheduled
+    Default: EmitStructuredArchiveSucceeded
+
+  EmitStructuredArchiveSucceeded:
+    Type: Task
+    Resource: arn:aws:states:::events:putEvents
+    Comment: "Emit SUCCEEDED event for Structured Archive branch"
+    Parameters:
+      Entries:
+        - Source: elephant.workflow
+          DetailType: WorkflowEvent
+          Detail:
+            executionId.$: $$.Execution.Name
+            county.$: $.pre.county_name
+            status: SUCCEEDED
+            phase: StructuredArchive
+            step: StructuredArchive
+            dataGroupLabel: County
+    ResultPath: $.eventResult
+    Next: WorkflowComplete
+    Catch:
+      - ErrorEquals: [States.ALL]
+        ResultPath: $.eventError
+        Next: WorkflowComplete
 
   WaitForTransformResolution:
     Type: Task


### PR DESCRIPTION
## Summary
- add workflowBranch validation/defaulting so omitted branch runs structured_archive and invalid values fail early
- route post-Transform default executions to StructuredArchive success while preserving explicit minting path through SVL/Hash/Upload/Submit
- document the branch language and ADR, and add ASL coverage for branch behavior
- add --workflow-branch structured_archive|minting to the start script

## Verification
- bash -n scripts/start-step-function.sh
- npm run typecheck
- npm run test
- AWS E2E smoke with profile elephant-oracle-node for Lee sample completed successfully after enabling required infra wiring

## E2E notes
- Created Lee prepare queue/event source mapping because the workflow requires per-county prepare queues: elephant-oracle-node-prepare-queue-lee
- Root cause of the >3 min stall was the Transform SQS -> Lambda event source mapping being disabled; re-enabled UUID 34038787-2bce-4a71-b773-c2e5430643bd
- Successful execution: e2e-structured-archive-lee-prepare-20260522-123859
- Output artifact: s3://elephant-oracle-node-environmentbucket-mmsoo3xbdi80/outputs/e2e-lee-structured-archive-20260522-120330/e2e-structured-archive-lee-prepare-20260522-123859/transformed_output.zip

## Worktree note
- prepare/template.yaml and scripts/deploy-infra.sh had pre-existing unstaged changes and are not included in this PR