### PR TITLE
fix(permit-harvest): resilient property-first parcels + Accela capture fixes

### DIFF
--- a/tests/workflow/lambdas/permit-harvest-worker/lee-accela.test.mjs
+++ b/tests/workflow/lambdas/permit-harvest-worker/lee-accela.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildPermitOutputStem,
   buildUnavailablePermitDetail,
@@ -114,6 +114,54 @@ describe("lee-accela permit harvest helpers", () => {
     expect(
       extractPermitLinksFromSearchHtml(html, "parcel-294627l40900c1787", 1),
     ).toEqual([]);
+  });
+
+  it("returns a detail link when the detail page has divRecordStatus and a related-conditions sub-grid with a Showing banner", () => {
+    // Empirical regression (Fix B structural guard): ~12.5% of real Accela
+    // CapDetail pages carry a "Showing X-Y of Z" banner inside a related-records
+    // or general-conditions sub-grid (e.g. gdvGeneralConditionsList inside
+    // divGeneralConditions). The old text-only guard wrongly returned null for
+    // those pages. The structural guard checks for the detail-page marker
+    // `divRecordStatus` and the main results-list grid `gdvPermitList` instead.
+    // A detail page that has `divRecordStatus` must always return the detail
+    // link even when its body text contains "Showing 1-5 of 5" from a sub-grid.
+    const html = `
+      <html><body>
+        <form id="aspnetForm" action="./CapDetail.aspx?Module=Permitting&capID1=26CAP&capID2=00000&capID3=00DEF&agencyCode=LEECO">
+          <div id="ctl00_PlaceHolderMain_divRecordStatus">
+            Message Bar Record &nbsp; MEC2025-00042 :&nbsp; Mechanical AC Replacement
+            Record Status: &nbsp; Permit Issued Click here for more information
+            Work Location 555 PALM AVE CAPE CORAL FL 33904 * Record Details
+          </div>
+          <div id="divGeneralConditions">
+            <table id="ctl00_PlaceHolderMain_capConditions_gdvGeneralConditionsList">
+              <tbody>
+                <tr><td>Condition A</td></tr>
+                <tr><td>Condition B</td></tr>
+              </tbody>
+            </table>
+            <span class="ACA_SmLabel ACA_SmLabel_FontSize">Showing 1-5 of 5 </span>
+          </div>
+        </form>
+      </body></html>`;
+
+    expect(
+      extractCurrentDetailPermitLinkFromHtml({
+        html,
+        pageUrl:
+          "https://aca-prod.accela.com/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=26CAP&capID2=00000&capID3=00DEF&agencyCode=LEECO",
+        sourceWindowKey: "parcel-111222333",
+        sourcePage: 1,
+      }),
+    ).toMatchObject({
+      recordNumber: "MEC2025-00042",
+      url: "https://aca-prod.accela.com/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=26CAP&capID2=00000&capID3=00DEF&agencyCode=LEECO",
+      address: "555 PALM AVE CAPE CORAL FL 33904",
+      description: "Mechanical AC Replacement",
+      status: "Permit Issued",
+      sourceWindowKey: "parcel-111222333",
+      sourcePage: 1,
+    });
   });
 
   it("parses common More Details fields and completed inspections", () => {
@@ -288,5 +336,261 @@ describe("lee-accela permit harvest helpers", () => {
     });
 
     expect(stem).toMatch(/^mec2025-02353-[a-f0-9]{12}$/);
+  });
+
+  // ─── Fix B: extractCurrentDetailPermitLinkFromHtml results-list guard ───────
+
+  it("returns null when the page has the main gdvPermitList results grid and no divRecordStatus (results list, not a detail redirect)", () => {
+    // A multi-result search page that happens to contain text matching the
+    // PERMIT_RECORD_HEADER_PATTERN (e.g. a record preview in the Accela
+    // message bar) must NOT be mistaken for a single-permit detail redirect.
+    // The structural discriminator (Fix B): gdvPermitList present + no
+    // divRecordStatus → results list → return null.
+    const html = `
+      <html><body>
+        <div class="aca_search_result">Showing 1-10 of 100 records found.</div>
+        <div>
+          Record ELE2025-00077 : Electrical Record Status: Closed-CC Issued
+          Click here for more information
+        </div>
+        <table id="ctl00_PlaceHolderMain_dgvPermitList_gdvPermitList">
+          <thead>
+            <tr>
+              <th></th><th>Record Number</th><th>Address</th><th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ACA_TabRow_Odd ACA_TabRow_Odd_FontSize">
+              <td><input type="checkbox"></td>
+              <td><div><a id="ctl00_PlaceHolderMain_dgvPermitList_gdvPermitList_ctl02_hlPermitNumber"
+                href="/LEECO/Cap/CapDetail.aspx?Module=Permitting&TabName=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO&IsToShowInspection=">
+                <strong><span>ELE2025-00077</span></strong></a></div></td>
+              <td><span>3150 MATECUMBE KEY RD, PUNTA GORDA FL 33955</span></td>
+              <td><span>Closed-CC Issued</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </body></html>`;
+
+    expect(
+      extractCurrentDetailPermitLinkFromHtml({
+        html,
+        pageUrl:
+          "https://aca-prod.accela.com/LEECO/Cap/CapHome.aspx?module=Permitting",
+        sourceWindowKey: "parcel-test001",
+        sourcePage: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a permit link when the page is a genuine detail redirect with no gdvPermitList grid", () => {
+    // A true single-record CapDetail.aspx redirect: record header present,
+    // no gdvPermitList grid, no divRecordStatus (falls through to
+    // PERMIT_RECORD_HEADER_PATTERN — the belt-and-suspenders fallback).
+    const html = `
+      <html><body>
+        <form id="aspnetForm" action="./CapDetail.aspx?Module=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO">
+          Message Bar Record &nbsp; ELE2025-00077 :&nbsp; Electrical
+          Record Status: &nbsp; Closed-CC Issued Click here for more information
+          Work Location 3150 MATECUMBE KEY RD PUNTA GORDA FL 33955 * Record Details
+        </form>
+      </body></html>`;
+
+    const result = extractCurrentDetailPermitLinkFromHtml({
+      html,
+      pageUrl:
+        "https://aca-prod.accela.com/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO",
+      sourceWindowKey: "parcel-test001",
+      sourcePage: 1,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.recordNumber).toBe("ELE2025-00077");
+    expect(result.url).toContain("CapDetail.aspx");
+    expect(result.sourceWindowKey).toBe("parcel-test001");
+    expect(result.sourcePage).toBe(1);
+  });
+
+  it("existing detail-redirect fixture still returns a link (Fix B regression)", () => {
+    // The fixture from the 'treats direct Accela detail redirects' test above
+    // must continue to resolve — it contains no Showing-banner and the Fix B
+    // guard must leave it untouched.
+    const html = `
+      <form id="aspnetForm" action="./CapDetail.aspx?Module=Permitting&capID1=26CAP&capID2=00000&capID3=009YW&agencyCode=LEECO">
+        Message Bar Record &nbsp; RES2026-01308 :&nbsp; Residential New Primary Structure
+        Record Status: &nbsp; Permit Issued Click here for more information
+        Work Location 21000 VERDANA VILLAGE BLVD ESTERO FL 33928 * Record Details
+        <table id="tableCapTreeList">
+          <caption>Related Records</caption>
+          <tr>
+            <th>Record Number</th><th>Record Type</th><th>Project Name</th><th>Date</th><th>View</th>
+          </tr>
+          <tr class="ACA_RelatedCap_Normal">
+            <td>RES2023-17583</td><td>Residential New Primary Structure</td><td>RELATED VILLA</td><td>12/21/2023</td>
+            <td><a href="../Cap/CapDetail.aspx?Module=Permitting&capID1=23CAP&capID2=00000&capID3=030B9&agencyCode=LEECO">View</a></td>
+          </tr>
+        </table>
+      </form>`;
+
+    expect(
+      extractCurrentDetailPermitLinkFromHtml({
+        html,
+        pageUrl:
+          "https://aca-prod.accela.com/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=26CAP&capID2=00000&capID3=009YW&agencyCode=LEECO",
+        sourceWindowKey: "parcel-294627l40900c1787",
+        sourcePage: 1,
+      }),
+    ).toMatchObject({ recordNumber: "RES2026-01308" });
+  });
+
+  // ─── Fix C: extractPermitLinksFromSearchHtml logger warn + correctness ──────
+
+  it("extracts all CapDetail links from a gdvPermitList results grid with multiple rows", () => {
+    // Verifies the happy path using production markup captured from Lee County
+    // Accela: two permit rows inside the standard gdvPermitList table.
+    const html = `
+      <html><body>
+        <div>Showing 1-2 of 2 records found.</div>
+        <table id="ctl00_PlaceHolderMain_dgvPermitList_gdvPermitList">
+          <thead>
+            <tr>
+              <th></th><th>Record Number</th><th>Address</th><th>Description</th>
+              <th>Status</th><th>Action</th><th>Related Records</th><th>Submittal Type</th><th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ACA_TabRow_Odd ACA_TabRow_Odd_FontSize">
+              <td><input type="checkbox"></td>
+              <td><div><a id="ctl00_PlaceHolderMain_dgvPermitList_gdvPermitList_ctl02_hlPermitNumber"
+                href="/LEECO/Cap/CapDetail.aspx?Module=Permitting&TabName=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO&IsToShowInspection=">
+                <strong><span>ELE2025-00077</span></strong></a></div></td>
+              <td><span>3150 MATECUMBE KEY RD, PUNTA GORDA FL 33955</span></td>
+              <td><span>Electrical Service</span></td>
+              <td><span>Closed-CC Issued</span></td>
+              <td></td><td>0</td><td>ePlan</td><td></td>
+            </tr>
+            <tr class="ACA_TabRow_Even ACA_TabRow_Even_FontSize">
+              <td><input type="checkbox"></td>
+              <td><div><a id="ctl00_PlaceHolderMain_dgvPermitList_gdvPermitList_ctl03_hlPermitNumber"
+                href="/LEECO/Cap/CapDetail.aspx?Module=Permitting&TabName=Permitting&capID1=25CAP&capID2=00000&capID3=002AB&agencyCode=LEECO&IsToShowInspection=">
+                <strong><span>MEC2025-00099</span></strong></a></div></td>
+              <td><span>100 MAIN ST, FORT MYERS FL 33901</span></td>
+              <td><span>HVAC Replacement</span></td>
+              <td><span>Permit Issued</span></td>
+              <td></td><td>1</td><td>Paper</td><td></td>
+            </tr>
+          </tbody>
+        </table>
+      </body></html>`;
+
+    const links = extractPermitLinksFromSearchHtml(html, "parcel-test999", 1);
+
+    expect(links).toHaveLength(2);
+    expect(links[0].recordNumber).toBe("ELE2025-00077");
+    expect(links[0].url).toBe(
+      "https://aca-prod.accela.com/LEECO/Cap/CapDetail.aspx?Module=Permitting&TabName=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO&IsToShowInspection=",
+    );
+    expect(links[0].address).toBe(
+      "3150 MATECUMBE KEY RD, PUNTA GORDA FL 33955",
+    );
+    expect(links[0].status).toBe("Closed-CC Issued");
+    expect(links[1].recordNumber).toBe("MEC2025-00099");
+    expect(links[1].sourcePage).toBe(1);
+    expect(links[1].sourceWindowKey).toBe("parcel-test999");
+  });
+
+  it("returns empty array and calls logger.warn when all CapDetail links are inside a related-records tree table", () => {
+    // Fix C: when every CapDetail anchor is filtered by isRelatedRecordTreeTable
+    // (id contains tableCapTreeList, or caption is 'Related Records'), the
+    // function must return [] AND emit the diagnostic warning — distinguishing
+    // an Accela table-structure change from a genuinely empty page.
+    const html = `
+      <html><body>
+        <div>Showing 1-2 of 2 records found.</div>
+        <table id="tableCapTreeList">
+          <caption>Related Records</caption>
+          <thead>
+            <tr>
+              <th>Record Number</th><th>Record Type</th><th>Project Name</th><th>Date</th><th>View</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ACA_RelatedCap_Normal">
+              <td>ELE2025-00077</td><td>Electrical</td><td>SERVICE UPGRADE</td><td>01/15/2025</td>
+              <td><a href="/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=25CAP&capID2=00000&capID3=001SR&agencyCode=LEECO">View</a></td>
+            </tr>
+            <tr class="ACA_RelatedCap_Normal">
+              <td>MEC2025-00099</td><td>Mechanical</td><td>HVAC</td><td>02/10/2025</td>
+              <td><a href="/LEECO/Cap/CapDetail.aspx?Module=Permitting&capID1=25CAP&capID2=00000&capID3=002AB&agencyCode=LEECO">View</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </body></html>`;
+
+    const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const links = extractPermitLinksFromSearchHtml(
+      html,
+      "parcel-test000",
+      2,
+      mockLogger,
+    );
+
+    expect(links).toEqual([]);
+    expect(mockLogger.warn).toHaveBeenCalledOnce();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "lee_search_links_all_filtered_as_related_records",
+      expect.objectContaining({
+        windowKey: "parcel-test000",
+        pageNumber: 2,
+        relatedRecordFilteredCount: 2,
+      }),
+    );
+  });
+
+  it("does not call logger.warn when the page has zero CapDetail links at all (genuinely empty)", () => {
+    // The warn is only for the case where links existed but were ALL filtered.
+    // A page with no CapDetail anchors at all (e.g. a no-results page) must
+    // return [] silently — no warn, because there is nothing to diagnose.
+    const html = `
+      <html><body>
+        <div>Your search returned no results.</div>
+      </body></html>`;
+
+    const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const links = extractPermitLinksFromSearchHtml(
+      html,
+      "parcel-empty",
+      1,
+      mockLogger,
+    );
+
+    expect(links).toEqual([]);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  // ─── Fix A contract: parseResultSummary change-detection baseline ───────────
+
+  it("parses the Showing-banner used by Fix A pagination change-detection", () => {
+    // Fix A snapshots the current summary before clicking Next, then waits for
+    // it to change. The normalized form produced by parseResultSummary must
+    // match what the in-browser normalization (match[1].replace(/\s+/g," ").trim())
+    // produces, so both sides compare like-for-like.
+    expect(parseResultSummary("Showing 1-10 of 100 records found.")).toEqual({
+      summary: "1-10 of 100",
+      total: 100,
+    });
+    expect(parseResultSummary("Showing 11-20 of 100 records found.")).toEqual({
+      summary: "11-20 of 100",
+      total: 100,
+    });
+    // The two summaries are distinct — change-detection between page 1 and
+    // page 2 will not false-positive by comparing equal strings.
+    expect(
+      parseResultSummary("Showing 1-10 of 100 records found.").summary,
+    ).not.toBe(
+      parseResultSummary("Showing 11-20 of 100 records found.").summary,
+    );
   });
 });

--- a/workflow/lambdas/permit-harvest-worker/index.mjs
+++ b/workflow/lambdas/permit-harvest-worker/index.mjs
@@ -2827,6 +2827,46 @@ async function processLeePropertyFirstPermitParcel(message) {
       stateUri,
       loadSummary,
     });
+  } catch (error) {
+    // Resilience: a single parcel failure (Accela search timeout, an
+    // incomplete-capture guard, or a missing-detail guard) must not dead-letter
+    // the message and stall the whole property-first run. Record the failure to
+    // a queryable failures ledger and return WITHOUT writing the completion
+    // state object, so the parcel stays "not completed" and is re-driven on the
+    // next run. No partial data is loaded to Neon (all guards throw before the
+    // load step).
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const failureKey = `${output.key}/lee/permit-parcel-failures/${searchKey}.json`;
+    await putTextObject({
+      bucket: output.bucket,
+      key: failureKey,
+      body: JSON.stringify(
+        {
+          schemaVersion: "permit-harvest.lee-property-first-state.v1",
+          event: "property_first_permit_failed",
+          failedAt: new Date().toISOString(),
+          jobId: message.jobId,
+          target,
+          error: errorMessage,
+        },
+        null,
+        2,
+      ),
+      contentType: "application/json; charset=utf-8",
+    }).catch((writeError) => {
+      consoleLogger.error("lee_property_first_parcel_failure_record_failed", {
+        jobId: message.jobId,
+        parcelIdentifier: target.parcelIdentifier,
+        error:
+          writeError instanceof Error ? writeError.message : String(writeError),
+      });
+    });
+    consoleLogger.error("lee_property_first_parcel_failed", {
+      jobId: message.jobId,
+      parcelIdentifier: target.parcelIdentifier,
+      normalizedParcelIdentifier: target.normalizedParcelIdentifier,
+      error: errorMessage,
+    });
   } finally {
     await browser.close().catch(() => undefined);
   }

--- a/workflow/lambdas/permit-harvest-worker/lee-accela.mjs
+++ b/workflow/lambdas/permit-harvest-worker/lee-accela.mjs
@@ -972,7 +972,15 @@ export async function searchLeePermitParcel({
       await page.waitForFunction(
         (previousSummary) => {
           const text = document.body?.innerText ?? "";
-          if (/Your search returned no results|No records found/i.test(text)) {
+          // Resolve immediately on no-results or any Accela error-page pattern.
+          // Without this, an error page would spin the full 90s timeout on every
+          // retry instead of fast-failing to the loop body's error detection.
+          // Patterns mirror waitForAccelaSearchOutcome and the loop body guard.
+          if (
+            /Your search returned no results|No records found|error\(s\) occurred on current page|unable to proceed|Object reference not set/i.test(
+              text,
+            )
+          ) {
             return true;
           }
           const match =

--- a/workflow/lambdas/permit-harvest-worker/lee-accela.mjs
+++ b/workflow/lambdas/permit-harvest-worker/lee-accela.mjs
@@ -473,13 +473,43 @@ export function extractCurrentDetailPermitLinkFromHtml({
   sourcePage,
 }) {
   const text = htmlToText(html);
+  const $ = cheerio.load(html);
+
+  // Structural discriminator: distinguish a genuine single-record detail page
+  // from a results-list page that may contain a record preview in its message
+  // bar (which would otherwise false-match PERMIT_RECORD_HEADER_PATTERN and
+  // prematurely break pagination).
+  //
+  // Key markers verified against real Accela HTML:
+  //   - `divRecordStatus`   — present on detail pages; absent on list pages.
+  //   - `gdvPermitList`     — the main permit results grid; present on list
+  //                           pages; absent on detail pages.
+  //
+  // Decision:
+  //   1. If divRecordStatus is found → definitely a detail page; proceed.
+  //   2. If gdvPermitList is found (and divRecordStatus is absent) → results
+  //      list; return null.
+  //   3. Neither marker present → fall through to PERMIT_RECORD_HEADER_PATTERN
+  //      (belt-and-suspenders for pages that predate or omit these markers).
+  //
+  // Text-only "Showing X-Y of Z" guards were intentionally removed: ~12.5% of
+  // real detail pages carry that banner inside a related-records or conditions
+  // sub-grid (e.g. gdvGeneralConditionsList), so text matching is unreliable.
+  const hasDetailMarker = $("[id*='divRecordStatus']").length > 0;
+  const hasListGrid = $("[id*='gdvPermitList']").length > 0;
+
+  if (hasDetailMarker) {
+    // Confirmed detail page — skip the null-return checks below.
+  } else if (hasListGrid) {
+    return null;
+  }
+  // else: neither marker; fall through and let PERMIT_RECORD_HEADER_PATTERN decide.
+
   const recordHeader = PERMIT_RECORD_HEADER_PATTERN.exec(text);
   if (recordHeader === null) return null;
 
   const recordNumber = readPermitRecordNumber(recordHeader[1]);
   if (recordNumber === null) return null;
-
-  const $ = cheerio.load(html);
   const formAction = $("form#aspnetForm").attr("action") ?? null;
   const sourceUrl = /CapDetail\.aspx/i.test(pageUrl)
     ? pageUrl
@@ -517,21 +547,32 @@ export function extractCurrentDetailPermitLinkFromHtml({
  * @param {string} html - Search result HTML.
  * @param {string} windowKey - Date-window key that produced this page.
  * @param {number} pageNumber - One-based page number.
+ * @param {Logger} [logger] - Structured logger used to surface zero-link diagnostics.
  * @returns {PermitLink[]} Extracted permit links.
  */
-export function extractPermitLinksFromSearchHtml(html, windowKey, pageNumber) {
+export function extractPermitLinksFromSearchHtml(
+  html,
+  windowKey,
+  pageNumber,
+  logger = consoleLogger,
+) {
   const $ = cheerio.load(html);
   /** @type {PermitLink[]} */
   const links = [];
+  const capDetailAnchors = $("a[href*='CapDetail.aspx']");
+  let relatedRecordFilteredCount = 0;
 
-  $("a[href*='CapDetail.aspx']").each((_, element) => {
+  capDetailAnchors.each((_, element) => {
     const anchor = $(element);
     const href = anchor.attr("href");
     if (!href) return;
 
     const row = anchor.closest("tr");
     const table = row.closest("table");
-    if (isRelatedRecordTreeTable(table)) return;
+    if (isRelatedRecordTreeTable(table)) {
+      relatedRecordFilteredCount += 1;
+      return;
+    }
 
     const cells = row
       .find("td")
@@ -576,6 +617,19 @@ export function extractPermitLinksFromSearchHtml(html, windowKey, pageNumber) {
       sourcePage: pageNumber,
     });
   });
+
+  // Distinguish "0 links because every CapDetail link was inside a
+  // related-record tree" from "genuinely 0 CapDetail links on the page".
+  // The former points at an Accela table-structure change that defeats
+  // isRelatedRecordTreeTable; the latter is an expected empty/no-results page.
+  if (links.length === 0 && relatedRecordFilteredCount > 0) {
+    logger.warn("lee_search_links_all_filtered_as_related_records", {
+      windowKey,
+      pageNumber,
+      capDetailAnchorCount: capDetailAnchors.length,
+      relatedRecordFilteredCount,
+    });
+  }
 
   return links;
 }
@@ -710,6 +764,7 @@ export async function searchLeePermitWindow({
         html,
         windowKey,
         pageNumber,
+        logger,
       );
       logger.info("lee_window_page_captured", {
         windowKey,
@@ -892,6 +947,7 @@ export async function searchLeePermitParcel({
         html,
         searchKey,
         pageNumber,
+        logger,
       );
       logger.info("lee_parcel_search_page_captured", {
         searchKey,
@@ -904,16 +960,30 @@ export async function searchLeePermitParcel({
       permits.push(...pageLinks);
 
       if (noResults) break;
+      // Snapshot the current page's result summary before clicking "Next >".
+      // The click triggers an ASP.NET UpdatePanel partial postback (no full
+      // navigation), so we must wait for the "Showing X-Y of Z" banner to
+      // CHANGE from this value before re-reading the DOM. Waiting only on
+      // waitForAccelaSearchOutcome here is unsafe: the stale prior-page banner
+      // still satisfies it, causing page.content() to re-read the old page.
+      const priorSummary = summary;
       const clicked = await clickNextResultPage(page);
       if (!clicked) break;
-      await Promise.race([
-        page.waitForNavigation({
-          waitUntil: "domcontentloaded",
-          timeout: 45000,
-        }),
-        sleep(6000),
-      ]).catch(() => undefined);
-      await waitForAccelaSearchOutcome(page);
+      await page.waitForFunction(
+        (previousSummary) => {
+          const text = document.body?.innerText ?? "";
+          if (/Your search returned no results|No records found/i.test(text)) {
+            return true;
+          }
+          const match =
+            /Showing\s+([0-9,]+\s*-\s*[0-9,]+\s+of\s+([0-9,]+))/i.exec(text);
+          if (match === null) return false;
+          const currentSummary = match[1].replace(/\s+/g, " ").trim();
+          return previousSummary === null || currentSummary !== previousSummary;
+        },
+        { timeout: 90000 },
+        priorSummary,
+      );
       await sleep(2000);
     }
   } finally {


### PR DESCRIPTION
## Problem
Lee County "property-first" permit harvest was dead-lettering parcels and stalling. Over 16 days of logs: ~429 "captured N of M reported permits" completeness failures + ~80 Accela search timeouts; 119 parcels in the DLQ. Root cause: a single parcel failure threw out of the SQS handler (batch size 1, no partial-batch handling) → 6 retries → DLQ; and the parcel search undercounted permits (pagination + detail-page misclassification).

## Changes
- **Resilience** (`index.mjs`): `processLeePropertyFirstPermitParcel` now catches any parcel failure, records it to a `permit-parcel-failures/<searchKey>.json` ledger, and returns without rethrowing — one bad parcel no longer dead-letters the run. Strict completeness guard kept; no partial Neon load (all guards throw before the load step). Failed parcels stay "not completed" and are re-driven on the next run.
- **Fix A — pagination** (`lee-accela.mjs`): Accela paginates via an ASP.NET UpdatePanel (AJAX postback) that `waitForNavigation` never observes. The loop now waits for the "Showing X-Y of Z" banner to *change* before reading the next page (fixes "captured 10 of 100").
- **Fix B — detail vs list** (`lee-accela.mjs`): replaced a text heuristic with a structural discriminator — `divRecordStatus` ⇒ detail page; `gdvPermitList` ⇒ results list. Fixes the false detail-page match (premature break / undercount) without misclassifying genuine detail pages that carry a related-records sub-grid "Showing" banner (verified ~12.5% of detail pages do).
- **Fix C — diagnostics** (`lee-accela.mjs`): warn when all CapDetail links are filtered out as related-records (an Accela table-structure canary).
- **Tests**: +8 unit tests (17 total) covering Fix B/C and the parse contract Fix A relies on.

Scoped to the property-first path; the deprecated date-window loop is untouched.

## Verification
- `tsc` typecheck clean (0 diagnostics) · vitest 17/17 · prettier clean · no secrets/account-ids in the diff.
- Fix A (browser pagination) isn't unit-testable without a real browser — to be confirmed by a pilot on the 119 previously-failed parcels before any full run.

Asana: Oracle story `1215644141347702`, subtask `1215776043809462`.
