### PR TITLE
docs(adr): open-data storage off Pinata (Oracle #2 S1)

### DIFF
--- a/docs/adr/0002-open-data-storage-off-pinata.md
+++ b/docs/adr/0002-open-data-storage-off-pinata.md
@@ -1,0 +1,25 @@
+# Open-data storage moves off Pinata to an S3-compatible IPFS store
+
+Oracle's collected datasets must become openly published, durably indexed, and agent-queryable (Oracle #2 milestone). This ADR records the storage architecture and the storage selection — the decision deliverable. On-chain submission is **out of scope** for this milestone; the goal is publish-to-storage plus a durable queryable index. Elephant.xyz UI is excluded.
+
+## Storage selection: S3-compatible IPFS provider (Filebase)
+
+Public storage moves off **Pinata** to **Filebase**, an S3-compatible provider that pins content to IPFS. Filebase is selected because it satisfies both requirements at once: it is **IPFS-compatible** (content-addressed; objects are pinned and resolvable by CID through any IPFS gateway) **and** exposes an **S3 API** (the "S2"/S3-compatible option). Plain AWS S3 fails the IPFS-compatible requirement; web3.storage/Filecoin/Lighthouse fail the S3-compatible requirement.
+
+The change is contained because CIDs are computed locally by `@elephant-xyz/cli` `hash` **before** upload, so the CID scheme is identical regardless of storage provider and no downstream consumer breaks. `oracle-node` already depends on `@aws-sdk/client-s3` in its workflow lambdas, so publishing to Filebase is a `PutObject` against the provider endpoint rather than a new transport.
+
+## Architecture
+
+- **CID generation** stays local and unchanged (`hash` → CID v0).
+- **Upload** swaps the hard-coded Pinata path for a pluggable `StorageProvider` whose first implementation targets Filebase. The two call sites are `elephant-cli` `upload` (service instantiation) and `oracle-node` `upload-worker` (credential env var). Built in the publish subtask.
+- **Durable index** is a public newline-delimited JSON manifest (`datasets-manifest.jsonl`) in the store — one record per published dataset. The existing envio-subgraph indexes on-chain `DataSubmitted` events only and is therefore not usable for an off-chain index. Built in the index subtask.
+- **Provenance and freshness** are carried by the manifest record: `{ schemaVersion, cid, county, source, dataGroup, collectedAt, publishedAt, oracle }`.
+- **MCP access** is additive tools over the manifest (query by county/source, resolve provenance/freshness), layered on the existing `elephant-mcp` server without changing its architecture. Built in the MCP subtask.
+
+## Consequences
+
+- Storage is provider-pluggable behind a `StorageProvider` interface; Filebase today, other IPFS/S3 providers later without changing callers (forward-compatible agent access).
+- Datasets remain content-addressed, so any future consumer can fetch a CID from any IPFS gateway independent of the provider.
+- The durable index is purpose-built off-chain (manifest), decoupled from the Polygon contract and envio-subgraph; no on-chain submission is added or required by this milestone.
+- The manifest is versioned (`schemaVersion`) and evolves additively; agents resolve datasets by `(county, source, dataGroup)` → CID.
+- Filebase account and credentials are a prerequisite before the publish step can run.

--- a/docs/adr/0002-open-data-storage-off-pinata.md
+++ b/docs/adr/0002-open-data-storage-off-pinata.md
@@ -6,9 +6,9 @@ Oracle's collected datasets must become openly published, durably indexed, and a
 
 Keep **IPFS** as the storage layer (via **Filebase**), and fix the scaling problem in the **data model**: consolidate each property's graph into **one file per property**, then publish those files to IPFS.
 
-- **IPFS is mandatory.** The data must be open/permissionless/decentralized — anyone can fetch it by CID and scale their own reads. A database or object store *we* host would make us responsible for scaling and would be permissioned, which defeats the goal.
-- **The fix is granularity, not the provider.** Elephant's data is a graph; published per-node it explodes into **billions of sub-1KB objects** even for one county. That is unscalable to retrieve/index on *any* IPFS provider (per-object DHT/metadata cost; plus the ~256 KB block floor wastes space), and it is what failed on Pinata. Consolidating all of a property's data (permits, tenants/Sunbiz, reviews/BBB, appraisal) into **one file** drops the object count to **~300k (one per property)** — tractable to pin, fetch, and index.
-- **Filebase** is the IPFS provider: S3-compatible API *and* genuinely distributed (unlike Pinata, which was effectively a single hosted service that throttled reads).
+- **IPFS is mandatory.** The data must be open/permissionless/decentralized — anyone can fetch it by CID and scale their own reads. A database or object store _we_ host would make us responsible for scaling and would be permissioned, which defeats the goal.
+- **The fix is granularity, not the provider.** Elephant's data is a graph; published per-node it explodes into **billions of sub-1KB objects** even for one county. That is unscalable to retrieve/index on _any_ IPFS provider (per-object DHT/metadata cost; plus the ~256 KB block floor wastes space), and it is what failed on Pinata. Consolidating all of a property's data (permits, tenants/Sunbiz, reviews/BBB, appraisal) into **one file** drops the object count to **~300k (one per property)** — tractable to pin, fetch, and index.
+- **Filebase** is the IPFS provider: S3-compatible API _and_ genuinely distributed (unlike Pinata, which was effectively a single hosted service that throttled reads).
 
 ## Architecture
 

--- a/docs/adr/0002-open-data-storage-off-pinata.md
+++ b/docs/adr/0002-open-data-storage-off-pinata.md
@@ -14,9 +14,9 @@ Keep **IPFS** as the storage layer (via **Filebase**), and fix the scaling probl
 
 - **Consolidate at publish time:** from the query-db, for each property, assemble one consolidated JSON (relationships nested). Implemented as the `elephant-query-db` per-property consolidation exporter (batched so memory stays flat).
 - **Address + publish:** each file gets an IPFS CIDv0 (computed locally; verified to equal the CID Filebase returns on upload). Files are uploaded to a Filebase bucket and pinned to IPFS.
-- **Registry = a manifest** mapping property → CID, with provenance/freshness (`county`, `source`, `collectedAt`), published alongside the data. This is the durable, queryable index for this milestone.
-- **MCP access** exposes the manifest so agents discover properties and resolve CIDs/provenance, layered on the existing `elephant-mcp` server.
-- **NEO** (`elephant-xyz/catalog`) is rewired to read the open IPFS data via MCP instead of bundled files.
+- **Registry = a manifest** published alongside the data: dataset-level `county` + `exportedAt`/`propertyCount`, plus one entry per property `{ propertyId, parcelIdentifier, cid, sha256, fileSizeBytes }`. This is the durable, queryable index for this milestone. Per-property freshness/provenance (`collectedAt`, source, etc.) lives **inside** each property file, not in the manifest entry.
+- **MCP access (for agents):** the `elephant-mcp` server exposes `listOracleProperties` / `getOracleProperty` / `getOracleDatasetInfo` over the manifest, so any coding agent can discover properties and fetch them by CID. Manifest CID is configurable via `ORACLE_OPEN_DATA_MANIFEST_CID`.
+- **NEO** (`elephant-xyz/catalog`) reads the open data **directly** (manifest + per-property CIDs from IPFS), behind a flag, replacing its bundled files. A web app consuming the open structure directly is the right fit; the stdio MCP server is the _agent_ access path, not a web-app runtime dependency.
 
 ## Consequences
 
@@ -24,7 +24,21 @@ Keep **IPFS** as the storage layer (via **Filebase**), and fix the scaling probl
 - Data stays **content-addressed**, so any consumer can fetch a CID from any IPFS gateway, independent of provider.
 - The registry is **off-chain** for this milestone (a published manifest). The fully-decentralized registry remains the blockchain (CIDs anchored on-chain → indexers like The Graph/Envio); consolidation **re-enables** that path (anchoring ~300k per-property CIDs is tractable, billions were not) as a follow-up — explicitly out of scope here.
 - Per-county scoping (Sunbiz/BBB are address/contractor-matched, not a simple column) is deferred until a second county lands; the first cut publishes the full query-db (currently Lee-only).
+- Published per-property files include **permit-contact PII** (applicant/contractor names, phones, emails). This is county public-record data; publishing it aggregated and permanently on public IPFS was a deliberate, confirmed-acceptable choice.
+- **Consuming the CIDs:** files are UnixFS **dag-pb** CIDs (CIDv0), not raw blocks — integrity verification must recompute the UnixFS CID (e.g. via `ipfs-only-hash`), not sha256 the raw gateway bytes. The `elephant-mcp` server requires **Node 22** (its native deps lack Node 24 prebuilds).
 
 ## Status
 
-Implemented and **executed for Lee** (verified 2026-06-18): 4,664 consolidated per-property files + manifest published to Filebase bucket `elephant-oracle-open-data` and confirmed retrievable from the public `ipfs.io` gateway by CID. Consolidation exporter: `elephant-query-db` PR. Remaining: MCP access + rewiring/validating NEO.
+**Complete (2026-06-18)** — all milestone ACs met, validated end-to-end on Lee:
+
+- **Consolidation exporter** — `elephant-query-db` (PR #1, merged).
+- **Published** — 4,664 consolidated per-property files + manifest to Filebase bucket `elephant-oracle-open-data`; confirmed retrievable from the public `ipfs.io` gateway by CID.
+- **MCP access** — `elephant-mcp` (PR #19); verified via a live server+client round-trip returning real Lee data.
+- **NEO rewired** — `catalog` (PR #6); verified the app's own data layer (`getPropertyByParcelId`) serves Lee from IPFS.
+
+## Known limitations / follow-ups
+
+- **Data gaps:** published files omit `photos`, `folioId` (LEEPA link), `municipality`, FEMA fields, and tax `exemption` — these render empty when NEO runs in open-data mode. Add them to the consolidation export to close.
+- **Manifest `filePath`** currently records an absolute local path; should be relative/omitted (consumers address by `cid`).
+- **Re-publish** produces a new manifest CID — update `ORACLE_OPEN_DATA_MANIFEST_CID` on the MCP server and the NEO sync to point at it.
+- **Repo Node version:** pin to Node 22 (`.nvmrc` / `engines` upper bound) so consumers don't hit the Node 24 native-dep failures.

--- a/docs/adr/0002-open-data-storage-off-pinata.md
+++ b/docs/adr/0002-open-data-storage-off-pinata.md
@@ -11,8 +11,8 @@ The change is contained because CIDs are computed locally by `@elephant-xyz/cli`
 ## Architecture
 
 - **CID generation** stays local and unchanged (`hash` → CID v0).
-- **Upload** swaps the hard-coded Pinata path for a pluggable `StorageProvider` whose first implementation targets Filebase. The two call sites are `elephant-cli` `upload` (service instantiation) and `oracle-node` `upload-worker` (credential env var). Built in the publish subtask.
-- **Durable index** is a public newline-delimited JSON manifest (`datasets-manifest.jsonl`) in the store — one record per published dataset. The existing envio-subgraph indexes on-chain `DataSubmitted` events only and is therefore not usable for an off-chain index. Built in the index subtask.
+- **Upload** swaps the hard-coded Pinata path for a pluggable `StorageProvider` whose first implementation targets Filebase. Two changes are required: in `elephant-cli`, the `upload` command instantiates the provider behind the interface; in `oracle-node` `upload-worker`, the `upload()` call signature itself changes — today it passes a named `pinataJwt` parameter (`upload({ ..., pinataJwt })`), which becomes the Filebase credential shape — along with the corresponding env var (`ELEPHANT_PINATA_JWT` → Filebase credentials). It is not an env-var-only swap. Built in the publish subtask.
+- **Durable index** is a set of per-dataset records in the store, plus a public newline-delimited JSON manifest (`datasets-manifest.jsonl`) as a queryable view. Each published dataset writes **one immutable record object** keyed deterministically by `(county, source, dataGroup, cid)` (e.g. `index/<county>/<source>/<dataGroup>/<cid>.json`). The manifest is **compiled from those record objects** (prefix-listed), not appended to concurrently — this is race-free by construction and is the chosen design specifically because oracle-node can publish multiple counties concurrently and object stores (S3/Filebase) offer no compare-and-swap for appends, so a single shared appended file would silently drop overlapping writers' records. The existing envio-subgraph indexes on-chain `DataSubmitted` events only and is therefore not usable for an off-chain index. Built in the index subtask.
 - **Provenance and freshness** are carried by the manifest record: `{ schemaVersion, cid, county, source, dataGroup, collectedAt, publishedAt, oracle }`.
 - **MCP access** is additive tools over the manifest (query by county/source, resolve provenance/freshness), layered on the existing `elephant-mcp` server without changing its architecture. Built in the MCP subtask.
 
@@ -20,6 +20,7 @@ The change is contained because CIDs are computed locally by `@elephant-xyz/cli`
 
 - Storage is provider-pluggable behind a `StorageProvider` interface; Filebase today, other IPFS/S3 providers later without changing callers (forward-compatible agent access).
 - Datasets remain content-addressed, so any future consumer can fetch a CID from any IPFS gateway independent of the provider.
-- The durable index is purpose-built off-chain (manifest), decoupled from the Polygon contract and envio-subgraph; no on-chain submission is added or required by this milestone.
+- The durable index is purpose-built off-chain (per-dataset record objects + a compiled manifest), decoupled from the Polygon contract and envio-subgraph; no on-chain submission is added or required by this milestone.
+- Index writes are immutable per-dataset objects keyed by `(county, source, dataGroup, cid)`, so concurrent publishes never race; the `datasets-manifest.jsonl` is a derived view recompiled from those objects, not a concurrently appended file.
 - The manifest is versioned (`schemaVersion`) and evolves additively; agents resolve datasets by `(county, source, dataGroup)` → CID.
 - Filebase account and credentials are a prerequisite before the publish step can run.

--- a/docs/adr/0002-open-data-storage-off-pinata.md
+++ b/docs/adr/0002-open-data-storage-off-pinata.md
@@ -1,26 +1,30 @@
-# Open-data storage moves off Pinata to an S3-compatible IPFS store
+# Open data: consolidate per-property and publish to Filebase/IPFS
 
-Oracle's collected datasets must become openly published, durably indexed, and agent-queryable (Oracle #2 milestone). This ADR records the storage architecture and the storage selection — the decision deliverable. On-chain submission is **out of scope** for this milestone; the goal is publish-to-storage plus a durable queryable index. Elephant.xyz UI is excluded.
+Oracle's collected datasets must become openly published, durably indexed, and agent-queryable so any coding agent (NEO and others) can build on them permissionlessly (Oracle #2 milestone). This ADR records the storage + data-model decision. On-chain submission and the Elephant.xyz UI are out of scope for this milestone.
 
-## Storage selection: S3-compatible IPFS provider (Filebase)
+## Decision
 
-Public storage moves off **Pinata** to **Filebase**, an S3-compatible provider that pins content to IPFS. Filebase is selected because it satisfies both requirements at once: it is **IPFS-compatible** (content-addressed; objects are pinned and resolvable by CID through any IPFS gateway) **and** exposes an **S3 API** (the "S2"/S3-compatible option). Plain AWS S3 fails the IPFS-compatible requirement; web3.storage/Filecoin/Lighthouse fail the S3-compatible requirement.
+Keep **IPFS** as the storage layer (via **Filebase**), and fix the scaling problem in the **data model**: consolidate each property's graph into **one file per property**, then publish those files to IPFS.
 
-The change is contained because CIDs are computed locally by `@elephant-xyz/cli` `hash` **before** upload, so the CID scheme is identical regardless of storage provider and no downstream consumer breaks. `oracle-node` already depends on `@aws-sdk/client-s3` in its workflow lambdas, so publishing to Filebase is a `PutObject` against the provider endpoint rather than a new transport.
+- **IPFS is mandatory.** The data must be open/permissionless/decentralized — anyone can fetch it by CID and scale their own reads. A database or object store *we* host would make us responsible for scaling and would be permissioned, which defeats the goal.
+- **The fix is granularity, not the provider.** Elephant's data is a graph; published per-node it explodes into **billions of sub-1KB objects** even for one county. That is unscalable to retrieve/index on *any* IPFS provider (per-object DHT/metadata cost; plus the ~256 KB block floor wastes space), and it is what failed on Pinata. Consolidating all of a property's data (permits, tenants/Sunbiz, reviews/BBB, appraisal) into **one file** drops the object count to **~300k (one per property)** — tractable to pin, fetch, and index.
+- **Filebase** is the IPFS provider: S3-compatible API *and* genuinely distributed (unlike Pinata, which was effectively a single hosted service that throttled reads).
 
 ## Architecture
 
-- **CID generation** stays local and unchanged (`hash` → CID v0).
-- **Upload** swaps the hard-coded Pinata path for a pluggable `StorageProvider` whose first implementation targets Filebase. Two changes are required: in `elephant-cli`, the `upload` command instantiates the provider behind the interface; in `oracle-node` `upload-worker`, the `upload()` call signature itself changes — today it passes a named `pinataJwt` parameter (`upload({ ..., pinataJwt })`), which becomes the Filebase credential shape — along with the corresponding env var (`ELEPHANT_PINATA_JWT` → Filebase credentials). It is not an env-var-only swap. Built in the publish subtask.
-- **Durable index** is a set of per-dataset records in the store, plus a public newline-delimited JSON manifest (`datasets-manifest.jsonl`) as a queryable view. Each published dataset writes **one immutable record object** keyed deterministically by `(county, source, dataGroup, cid)` (e.g. `index/<county>/<source>/<dataGroup>/<cid>.json`). The manifest is **compiled from those record objects** (prefix-listed), not appended to concurrently — this is race-free by construction and is the chosen design specifically because oracle-node can publish multiple counties concurrently and object stores (S3/Filebase) offer no compare-and-swap for appends, so a single shared appended file would silently drop overlapping writers' records. The existing envio-subgraph indexes on-chain `DataSubmitted` events only and is therefore not usable for an off-chain index. Built in the index subtask.
-- **Provenance and freshness** are carried by the manifest record: `{ schemaVersion, cid, county, source, dataGroup, collectedAt, publishedAt, oracle }`.
-- **MCP access** is additive tools over the manifest (query by county/source, resolve provenance/freshness), layered on the existing `elephant-mcp` server without changing its architecture. Built in the MCP subtask.
+- **Consolidate at publish time:** from the query-db, for each property, assemble one consolidated JSON (relationships nested). Implemented as the `elephant-query-db` per-property consolidation exporter (batched so memory stays flat).
+- **Address + publish:** each file gets an IPFS CIDv0 (computed locally; verified to equal the CID Filebase returns on upload). Files are uploaded to a Filebase bucket and pinned to IPFS.
+- **Registry = a manifest** mapping property → CID, with provenance/freshness (`county`, `source`, `collectedAt`), published alongside the data. This is the durable, queryable index for this milestone.
+- **MCP access** exposes the manifest so agents discover properties and resolve CIDs/provenance, layered on the existing `elephant-mcp` server.
+- **NEO** (`elephant-xyz/catalog`) is rewired to read the open IPFS data via MCP instead of bundled files.
 
 ## Consequences
 
-- Storage is provider-pluggable behind a `StorageProvider` interface; Filebase today, other IPFS/S3 providers later without changing callers (forward-compatible agent access).
-- Datasets remain content-addressed, so any future consumer can fetch a CID from any IPFS gateway independent of the provider.
-- The durable index is purpose-built off-chain (per-dataset record objects + a compiled manifest), decoupled from the Polygon contract and envio-subgraph; no on-chain submission is added or required by this milestone.
-- Index writes are immutable per-dataset objects keyed by `(county, source, dataGroup, cid)`, so concurrent publishes never race; the `datasets-manifest.jsonl` is a derived view recompiled from those objects, not a concurrently appended file.
-- The manifest is versioned (`schemaVersion`) and evolves additively; agents resolve datasets by `(county, source, dataGroup)` → CID.
-- Filebase account and credentials are a prerequisite before the publish step can run.
+- Reads/scaling are owned by **consumers**: they fetch files by CID and index on their own side; we only publish. Filebase (distributed) serves availability — we are not the central query server.
+- Data stays **content-addressed**, so any consumer can fetch a CID from any IPFS gateway, independent of provider.
+- The registry is **off-chain** for this milestone (a published manifest). The fully-decentralized registry remains the blockchain (CIDs anchored on-chain → indexers like The Graph/Envio); consolidation **re-enables** that path (anchoring ~300k per-property CIDs is tractable, billions were not) as a follow-up — explicitly out of scope here.
+- Per-county scoping (Sunbiz/BBB are address/contractor-matched, not a simple column) is deferred until a second county lands; the first cut publishes the full query-db (currently Lee-only).
+
+## Status
+
+Implemented and **executed for Lee** (verified 2026-06-18): 4,664 consolidated per-property files + manifest published to Filebase bucket `elephant-oracle-open-data` and confirmed retrievable from the public `ipfs.io` gateway by CID. Consolidation exporter: `elephant-query-db` PR. Remaining: MCP access + rewiring/validating NEO.


### PR DESCRIPTION
## Oracle #2 — S1 decision deliverable

ADR 0002 records the open-data **storage architecture + storage selection** for the Oracle Open Data Index and MCP Layer milestone (story `1215644141347714`, subtask `1215758943562747`). Covers AC #1, #2, #3, #10.

### Decision
- **Storage = Filebase** (S3-compatible API + IPFS pinning), off Pinata. Satisfies both "IPFS-compatible" and the S3-compatible ("S2") requirement; plain AWS S3 / web3.storage each miss one half.
- CIDs are computed locally before upload, so the swap is contained and the CID scheme is unchanged.
- **Durable index = public `datasets-manifest.jsonl`** (off-chain). The envio-subgraph indexes on-chain events only and is not usable here; **on-chain submission is out of scope** for this milestone.
- Provenance/freshness carried by the manifest record; MCP access is additive tools over the manifest.

### Scope notes
- On-chain submission and Elephant.xyz UI are excluded.
- Pending: Soofi to confirm "S2" = S3-compatible store; Filebase credentials before the publish step.