### PR TITLE
fix(workflow): SVL-validate archive + property-first parcels (per-stage validation)

### DIFF
--- a/tests/workflow/state-machines/elephant-express.test.mjs
+++ b/tests/workflow/state-machines/elephant-express.test.mjs
@@ -67,13 +67,19 @@ describe("Elephant Express workflow branch selection", () => {
     });
   });
 
-  it("routes the default post-transform branch to Structured Archive", async () => {
+  it("routes the default post-transform branch through the SVL gate to Structured Archive", async () => {
     const definition = await loadStateMachine();
 
     expect(definition.States.EmitTransformSucceeded.Next).toBe(
       "ChoosePostTransformBranch",
     );
+    // Non-minting (default) branches now pass through the archive SVL gate first,
+    // then resume to Structured Archive once SVL passes.
     expect(definition.States.ChoosePostTransformBranch).toMatchObject({
+      Type: "Choice",
+      Default: "EmitArchiveSvlScheduled",
+    });
+    expect(definition.States.ChooseArchivePostSvl).toMatchObject({
       Type: "Choice",
       Default: "EmitStructuredArchiveSucceeded",
     });
@@ -105,7 +111,9 @@ describe("Elephant Express workflow branch selection", () => {
   it("routes seeded property-first appraisal executions to the permit queue after transform", async () => {
     const definition = await loadStateMachine();
 
-    expect(definition.States.ChoosePostTransformBranch.Choices).toContainEqual({
+    // Post-transform, non-minting branches now pass through the archive SVL gate first;
+    // the property-first permit routing resumes in ChooseArchivePostSvl (after SVL passes).
+    expect(definition.States.ChooseArchivePostSvl.Choices).toContainEqual({
       Variable: "$.message.propertyFirstPermitQueueUrl",
       IsPresent: true,
       Next: "ChoosePropertyFirstPermitEligibility",

--- a/tests/workflow/state-machines/elephant-express.test.mjs
+++ b/tests/workflow/state-machines/elephant-express.test.mjs
@@ -194,4 +194,30 @@ describe("Elephant Express workflow branch selection", () => {
       Next: "WorkflowComplete",
     });
   });
+
+  it("emits an SVL SUCCEEDED event on the archive happy path before resuming routing", async () => {
+    const definition = await loadStateMachine();
+
+    // Mirrors the minting EmitSvlSucceeded so monitors see archive/property-first
+    // parcels complete SVL instead of appearing stuck at SCHEDULED.
+    expect(definition.States.CheckArchiveSvlResult.Default).toBe(
+      "EmitArchiveSvlSucceeded",
+    );
+    expect(definition.States.EmitArchiveSvlSucceeded).toMatchObject({
+      Type: "Task",
+      Resource: "arn:aws:states:::events:putEvents",
+      Parameters: {
+        Entries: [
+          {
+            Detail: {
+              status: "SUCCEEDED",
+              phase: "SVL",
+              step: "SVL",
+            },
+          },
+        ],
+      },
+      Next: "ChooseArchivePostSvl",
+    });
+  });
 });

--- a/workflow/state-machines/elephant-express.asl.yaml
+++ b/workflow/state-machines/elephant-express.asl.yaml
@@ -443,11 +443,85 @@ States:
 
   ChoosePostTransformBranch:
     Type: Choice
-    Comment: "Choose Structured Archive by default, enqueue property-first permits for seeded Lee runs, or Minting when explicitly requested"
+    Comment: "Choose Structured Archive by default, enqueue property-first permits for seeded Lee runs, or Minting when explicitly requested. Archive + property-first now run SVL validation first (parity with minting) so no parcel is loaded/enqueued without schema validation."
     Choices:
       - Variable: $.workflowBranch
         StringEquals: minting
         Next: EmitSvlScheduled
+    Default: EmitArchiveSvlScheduled
+
+  EmitArchiveSvlScheduled:
+    Type: Task
+    Resource: arn:aws:states:::events:putEvents
+    Comment: "Emit SCHEDULED event for the archive/property-first SVL validation gate"
+    Parameters:
+      Entries:
+        - Source: elephant.workflow
+          DetailType: WorkflowEvent
+          Detail:
+            executionId.$: $$.Execution.Name
+            county.$: $.pre.county_name
+            status: SCHEDULED
+            phase: SVL
+            step: SVL
+            dataGroupLabel: County
+    ResultPath: $.eventResult
+    Next: ArchiveSvl
+    Catch:
+      - ErrorEquals: [States.ALL]
+        ResultPath: $.eventError
+        Next: ArchiveSvl
+
+  ArchiveSvl:
+    Type: Task
+    Resource: arn:aws:states:::sqs:sendMessage.waitForTaskToken
+    Comment: "Run Schema Validation Layer for archive/property-first parcels (parity with minting). A parcel must validate before it is loaded to Neon or enqueued for permits."
+    Parameters:
+      QueueUrl: ${SvlQueueUrl}
+      MessageBody:
+        taskToken.$: $$.Task.Token
+        input:
+          transformedOutputS3Uri.$: $.transform.transformedOutputS3Uri
+          county.$: $.pre.county_name
+          outputPrefix.$: $.pre.output_prefix
+          executionId.$: $$.Execution.Name
+          preparedS3Uri.$: $.prepare.output_s3_uri
+          s3.$: $.message.s3
+    ResultSelector:
+      validatedOutputS3Uri.$: $.validatedOutputS3Uri
+      county.$: $.county
+      executionId.$: $$.Execution.Name
+      validationPassed.$: $.validationPassed
+      svlErrors.$: $.svlErrors
+    ResultPath: $.svl
+    Next: CheckArchiveSvlResult
+    Retry:
+      - ErrorEquals: [States.Timeout]
+        IntervalSeconds: 5
+        MaxAttempts: 2
+        BackoffRate: 2
+    Catch:
+      - ErrorEquals: [SvlFailedError]
+        Comment: "SVL validation failed - park for resolution (retry target is Transform)"
+        ResultPath: $.svlError
+        Next: WaitForSvlExceptionResolution
+      - ErrorEquals: [States.ALL]
+        ResultPath: $.svlError
+        Next: WaitForSvlExceptionResolution
+
+  CheckArchiveSvlResult:
+    Type: Choice
+    Comment: "Fail-closed: a parcel that does not validate is parked, never loaded/enqueued"
+    Choices:
+      - Variable: $.svl.validationPassed
+        BooleanEquals: false
+        Next: WaitForSvlValidationResolution
+    Default: ChooseArchivePostSvl
+
+  ChooseArchivePostSvl:
+    Type: Choice
+    Comment: "After SVL passes, resume the original archive/property-first routing"
+    Choices:
       - Variable: $.message.propertyFirstPermitQueueUrl
         IsPresent: true
         Next: ChoosePropertyFirstPermitEligibility

--- a/workflow/state-machines/elephant-express.asl.yaml
+++ b/workflow/state-machines/elephant-express.asl.yaml
@@ -516,7 +516,29 @@ States:
       - Variable: $.svl.validationPassed
         BooleanEquals: false
         Next: WaitForSvlValidationResolution
-    Default: ChooseArchivePostSvl
+    Default: EmitArchiveSvlSucceeded
+
+  EmitArchiveSvlSucceeded:
+    Type: Task
+    Resource: arn:aws:states:::events:putEvents
+    Comment: "Emit SUCCEEDED event for SVL step on the archive / property-first branch, mirroring the minting EmitSvlSucceeded so monitors observe archive parcels completing SVL (not stuck at SCHEDULED)"
+    Parameters:
+      Entries:
+        - Source: elephant.workflow
+          DetailType: WorkflowEvent
+          Detail:
+            executionId.$: $$.Execution.Name
+            county.$: $.pre.county_name
+            status: SUCCEEDED
+            phase: SVL
+            step: SVL
+            dataGroupLabel: County
+    ResultPath: $.eventResult
+    Next: ChooseArchivePostSvl
+    Catch:
+      - ErrorEquals: [States.ALL]
+        ResultPath: $.eventError
+        Next: ChooseArchivePostSvl
 
   ChooseArchivePostSvl:
     Type: Choice


### PR DESCRIPTION
## Problem
Per-stage validation gap surfaced by the Lee appraisal corruption. `ChoosePostTransformBranch` only routes the **minting** branch through SVL. The **Structured Archive default** and the **property-first path** (Lee fullcounty) skip SVL entirely — transformed parcels are uploaded to S3, **loaded to Neon, and enqueued for permits with no schema/content validation**. A transform that "succeeds" but emits wrong/incomplete output passes silently.

## Fix (state-machine wiring only)
Reuses the existing `svl-worker` / `validate()` — no new validator. Routes all non-minting parcels through an SVL gate before they continue:
- `EmitArchiveSvlScheduled` -> `ArchiveSvl` (same `SvlQueueUrl` + `waitForTaskToken` as minting).
- `CheckArchiveSvlResult` — **fail-closed**: `validationPassed=false` parks the parcel (reuses `WaitForSvlValidationResolution`; retry target is Transform).
- `ChooseArchivePostSvl` — on pass, resumes the original property-first-vs-archive routing.

So no parcel is loaded/enqueued without passing SVL — parity with minting.

## Validation done
- ASL YAML parses (80 states); every `Next`/`StartAt` target resolves; no orphaned states.

## Needs before merge
Changes the **live scrape state machine**; a full execution was not run locally. Please deploy to a dev/staging stack and run one parcel through each path (archive default, property-first eligible, property-first skipped, and a deliberately-invalid transform to confirm it parks) before merging.

Generated with Claude Code