### PR TITLE
Make property-first seed-feeder county-generic (+ Palm Beach sender)

### DIFF
--- a/.agents/skills/county-appraisal-onboarding/SKILL.md
+++ b/.agents/skills/county-appraisal-onboarding/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: county-appraisal-onboarding
+description: Wire a new county's appraisal scraping into oracle-node - browser flow JSON, per-county prepare queue, per-county prepare flags, and transform scripts from Counties-trasform-scripts. Use when onboarding a county's property appraiser site, creating browser flows, or when prepare fails for a specific county.
+metadata:
+  author: elephant-xyz
+---
+
+# County Appraisal Onboarding
+
+Goal: a workflow execution for one parcel of the new county completes Prepare → Transform
+→ Structured Archive.
+
+## 1. Browser flow
+
+Prepare runs `elephant-cli prepare` against the appraiser site. If plain fetch works the
+flow may not need a browser; most counties need a Browser Flow v2 JSON.
+
+1. Check `oracle-node/browser-flows/` for an existing `<County>*.json` (Lee has
+   `LeeCurated.json`, `LeeCostCard.json` — use them as templates).
+2. Author the flow: navigate → fill the parcel search input (selector from discovery) →
+   submit → capture detail page(s) and any media/cost-card subpages. Capture as much of
+   the site's data as possible — images and secondary tabs included; the Lee run's explicit
+   requirement was "extract as much data as possible".
+3. Test locally against 3+ parcels of different property types:
+
+```bash
+npx elephant-cli prepare <parcel-or-url> \
+  --browser-flow <flow.json> --browser-flow-parameters '{"parcel_id":"..."}'
+```
+
+4. Per-county prepare flags (set at deploy, stored as env on the downloader):
+   `ELEPHANT_PREPARE_USE_BROWSER_<County>`, continue-button selector, captcha flags —
+   see `oracle-node/README.md` "Prepare function flags".
+
+## 2. Per-county prepare queue
+
+```bash
+./scripts/create-county-prepare-queue.sh <county_key>
+```
+
+This creates `<stack>-prepare-queue-<county_key>` with its own event-source mapping so the
+county's portal tolerance can be tuned independently (start `MaximumConcurrency` low,
+raise while watching errors — Lee sustained 50+, but only after burn-in).
+
+## 3. Transform scripts (reuse first)
+
+County transform scripts live in `github.com/elephant-xyz/Counties-trasform-scripts`
+under `<county>/scripts/` (`data_extractor.js` + mapping modules), synced to S3 for the
+transform worker. The scripts-manager matches county-name variants (spaces, underscores,
+hyphens).
+
+1. If the county folder EXISTS: do not trust it blindly. Run the `validate-county-transform`
+   skill against fresh prepare captures covering data variability. Fix gaps before scaling.
+2. If it does NOT exist: author a transform v2 handler package — use the
+   `transform-v2-builder` skill — then validate the same way. New or changed scripts must
+   be committed on a branch and PR'd to `Counties-trasform-scripts` (`gh pr create`) —
+   never left only in a local checkout or only synced to S3.
+3. The transform must emit `data/property.json` with `property_usage_type`; the
+   post-transform permit-eligibility branch reads it.
+
+## 4. Usage-type eligibility
+
+Collect the county's usage-type labels (from transform output, not from the portal UI) and
+decide the eligible set for property-first permit harvest. Configure via the
+`PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES` env (CSV) on the transform and permit
+workers; defaults live in `workflow/lambdas/transform-worker/index.mjs` and
+`workflow/lambdas/permit-harvest-worker/index.mjs` and are keyed to LEE vocabulary — a new
+county almost certainly needs an override.
+
+## 5. Smoke test
+
+Send one workflow message for one parcel (see `county-ingest-run` for message shape) and
+verify in order: prepare capture zip in S3 → transform artifact zip → structured-archive
+success event → eligibility manifest present. Use
+`npm run query-post-logs` and CloudWatch logs for the downloader/transform workers when
+debugging.
+
+## Gotchas
+
+- Geo-blocking: some county portals block datacenter IPs; proxy rotation is supported via
+  `PROXY_FILE` (see README) and was needed intermittently for Lee.
+- A transform-script county-name mismatch can silently produce wrong-county labels in
+  output (the "Columbia county" incident) — verify `county_jurisdiction` in transformed
+  output equals the expected county.
+
+## Transform worker tuning (heavy parcels)
+
+The default `TransformWorkerFunction` config (512 MB / 300 s) is **too low for heavy
+parcels** (400+ data files in `output.zip`). Two failure modes observed in Lee full-county
+ingestion:
+
+| Failure | Root cause | Fix |
+|---------|-----------|-----|
+| 300 s TIMEOUT | 512 MB = too little CPU allocation; transform takes 30–180 s on arm64 at 512 MB | Bump MemorySize (more RAM = more vCPU) |
+| EMFILE "too many open files" | CLI's `transform()` opens 400+ files concurrently, hitting Lambda's 1024-fd limit | `graceful-fs` patch queues retries on EMFILE |
+
+**Production settings (in `prepare/template.yaml`, `TransformWorkerFunction`):**
+
+```yaml
+MemorySize: 3008   # was 512 — more RAM = proportionally more vCPU on Lambda
+Timeout: 900       # was 300 — max allowed; covers worst-case heavy parcels
+```
+
+**EMFILE fix (in `workflow/lambdas/transform-worker/index.mjs`):**
+
+`graceful-fs` is patched onto Node's built-in `fs` at module init time via `createRequire`.
+This intercepts EMFILE errors from the CLI library (even CJS internals) and queues
+retries automatically. Added as a dependency in the transform-worker `package.json`.
+
+**Deploy after any config change:**
+
+```bash
+AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 ./scripts/deploy-infra.sh
+```
+
+This runs `sam build` + `sam deploy` against `prepare/template.yaml` on stack
+`elephant-oracle-node`. The IaC change is the durable fix; a temporary CLI bump
+(`aws lambda update-function-configuration`) can be applied for immediate relief before
+the next deploy.

--- a/.agents/skills/county-ingest-run/SKILL.md
+++ b/.agents/skills/county-ingest-run/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: county-ingest-run
+description: Deploy and run the end-to-end property-first ingestion for an onboarded county - pilot batch first, then the full backpressure-aware seed-feeder run with concurrency ramp-up. Use when starting, scaling, resuming, or wrapping up a county ingestion run on AWS.
+metadata:
+  author: elephant-xyz
+---
+
+# County Ingest Run
+
+Prerequisites: `bootstrap-oracle-infra` checks pass; appraisal onboarding, transform
+validation, and the permit adapter are done for the county.
+
+Run parameters (AWS profile/region, job-id, pilot vs full scope, seed CSV) come from the
+`onboard-county` intake — don't re-ask what's already established. If entered directly
+without that context, ask for the missing parameters once before starting: a run sends
+sustained traffic to county websites and should never start on guessed inputs.
+
+## Run shape
+
+Property-first: each parcel flows appraisal-prepare → transform (Structured Archive) →
+eligibility branch → permit harvest → Neon, individually. Input is ONLY the seed CSV
+(never re-derive work from Neon), drip-fed by a self-requeuing seed-feeder SQS message
+with backpressure — never dump the whole county into SQS at once (516k messages exceeds
+retention and removes flow control).
+
+## 1. Pilot (always first)
+
+1. Pick 10-50 parcels from the seed covering usage-type variability (include commercial so
+   the permit path is exercised, and residential to verify the skip path).
+2. Use the one-shot enqueue script pattern (`scripts/enqueue-lee-appraisal-property-first-from-seed.mjs`,
+   cloned/parameterized for the county) with `--limit`, a distinct `--job-id`
+   (`<county>-property-first-pilot-<date>`), and `--dry-run` first.
+3. Verify per parcel, in order: prepare zip → transform artifact → eligibility manifest →
+   (eligible only) permit-list + extracted permit JSONs in S3 → rows in Neon
+   (`properties`, permit tables) → completion-state object written.
+4. Verify a permit-less parcel completes cleanly and a residential parcel stops after
+   archive with a skip marker.
+
+## 2. Full run
+
+Send the seed-feeder message (type `<county>-property-first-seed-feeder`) to the
+permit-harvest queue. Key message fields (see `validatePermitHarvestMessage()` for the
+contract):
+
+- `jobId` — `<county>-property-first-seed-all-<date>`; all S3 state is keyed by it
+- `sourceCsvS3Uri` — `s3://counties-seeds/<county>.csv`
+- `batchSize` (~100), `requeueDelaySeconds` (900), `sendDelayMs`
+- `skipExistingNeon: true` — dedupe against already-loaded parcels
+- `backpressureQueues` — caps per queue; starting point: workflow ≤250, prepare ≤5000,
+  transform ≤100, property-first-permit ≤200
+- output prefixes: seeds under `seed-inputs/<jobId>/`, workflow outputs under
+  `outputs/<jobId>/`, permit artifacts under `permit-harvest/<jobId>/`
+
+The feeder checkpoints at `permit-harvest/<jobId>/feeder-state.json` (row offset) and
+self-requeues until `sourceExhausted`. Resume = send the same message again; the
+checkpoint prevents re-queuing.
+
+## 3. Full-coverage permit redrive
+
+Use when a run was first gated to commercial/permit-priority appraiser usage types
+and the product decision changes to all-parcel permit coverage.
+
+1. Widen eligibility deliberately. For Lee, set
+   `PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES=__ALL__` on both the transform worker
+   and the permit-harvest worker after deploying code that treats `__ALL__` as full
+   coverage. Empty/unset is NOT full coverage; it falls back to the default
+   commercial/permit-priority list.
+2. Do not replay the whole seed through appraisal if transformed outputs already
+   exist. Redrive from the existing
+   `outputs/<jobId>/**/property_first_permit_eligibility.json` manifests where
+   `shouldEnqueue=false`.
+3. Use the checkpointed helper (`scripts/redrive-lee-full-coverage-permits.mjs` for
+   Lee) in dry-run mode first, then a 50-parcel pilot, then the full run. Enqueue mode
+   requires `--ack-workers-full-coverage` after verifying both workers are deployed and
+   configured with `PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES=__ALL__`. Messages must
+   keep `skipExisting=true`, `skipCompleted=true`, `loadToNeon=true`, and
+   `loadAppraisalToNeon=true` unless a fresh Neon reconciliation proves appraisal
+   loading should be skipped.
+4. The helper checkpoint belongs under the permit-harvest job prefix, e.g.
+   `permit-harvest/<jobId>/full-coverage-redrive-state.json`. Resume by rerunning the
+   same command; do not reset the checkpoint unless intentionally starting over. The
+   helper advances past malformed manifests and records them in checkpoint failure
+   metadata so one poison-pill object cannot block the county-scale run.
+5. Proxy capacity is required for a ~14-day Lee-scale run. Load real proxy credentials
+   before increasing permit concurrency beyond the direct-egress baseline. The
+   permit worker supports `PERMIT_HARVEST_PROXY_URL=<user:pass@host:port>` or
+   `PERMIT_HARVEST_PROXY_URLS` as a comma/newline-delimited list; without these env
+   vars, permit harvest uses direct Lambda egress even if the shared proxy table has
+   entries.
+6. Keep the redrive bounded by queue backpressure. Do not enqueue hundreds of
+   thousands of SQS messages at once; feed in batches and let the permit worker drain.
+
+## 3b. Transform-only redrive
+
+Use when a job has `output.zip` (prepare complete) for a large number of parcels
+but the transform stage failed or was never reached — producing no
+`<uuid>/transformed_output.zip`. This avoids re-scraping the appraisal site.
+
+The verified mechanism is **direct Lambda invocation** of the TransformWorkerFunction
+with `directInvocation: true` (same path used by the error-resolver). No SQS task
+token, no permit harvest, no SF execution needed.
+
+Script: `scripts/redrive-lee-transform-only.mjs` (Lee / `lee-fullcounty-20260619`).
+Adapt `--job-id`, `--bucket`, `--transform-fn` for other counties.
+
+### Workflow
+
+1. **Dry-run first** — enumerates every row folder that has `output.zip` but no
+   `<uuid>/transformed_output.zip`. Reports target count and estimated duration.
+   Full flat S3 scan (~2 min for 516k rows / 2M keys):
+   ```
+   AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+     node scripts/redrive-lee-transform-only.mjs --dry-run
+   ```
+2. **Pilot (--limit 20)** — live-invoke a bounded set, verify each wrote
+   `transformed_output.zip`:
+   ```
+   AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+     node scripts/redrive-lee-transform-only.mjs --limit 20
+   ```
+3. **Full run detached** — nohup into `.redrive-logs/`; survives shell exit:
+   ```
+   mkdir -p oracle-node/.redrive-logs
+   nohup env AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+     node scripts/redrive-lee-transform-only.mjs \
+     > oracle-node/.redrive-logs/transform-redrive.log 2>&1 &
+   echo "PID: $!"
+   ```
+
+### Key parameters
+- `--concurrency <n>` — parallel Lambda invocations (default 100; Lambda fn has no
+  reserved-concurrency cap, event-source map MaxConcurrency=100).
+- `--limit <n>` — stop after N parcels (0 = unlimited).
+- `--checkpoint-every <n>` — write S3 checkpoint every N completed parcels (default 50).
+- `--reset-checkpoint` — restart from row 0, ignoring existing checkpoint.
+
+### Checkpoint
+Written to `s3://<bucket>/permit-harvest/<jobId>/transform-redrive-state.json`.
+Resume a partial run by re-running the same command (checkpoint skips already-done rows
+automatically). Full run at concurrency 100 takes ~5.8 h for ~70k missing parcels (~$18).
+
+### Verified pilot (2026-06-22)
+20/20 parcels succeeded at rows 200000-200019. Each wrote
+`<row>/<executionId>/transformed_output.zip` + `property_first_permit_eligibility.json`.
+Per-parcel duration 24-39 s (avg ~30 s). `directInvocation=true` confirmed transform-only
+— no permit harvest triggered.
+
+### Monitoring
+```bash
+# Watch the log (detached run)
+tail -f oracle-node/.redrive-logs/transform-redrive.log
+
+# Check checkpoint state
+aws s3 cp s3://<bucket>/permit-harvest/<jobId>/transform-redrive-state.json - \
+  | python3 -m json.tool
+
+# Resume after interruption — just re-run the same full-run command
+```
+
+### After the transform redrive completes
+Load results to Neon via the `query-db-loading-matching` skill.
+
+## 4. Ramp-up
+
+1. Watch with `monitoring-county-ingestion` after each change; let each setting burn in
+   10+ minutes before the next.
+2. Raise prepare/transform event-source `MaximumConcurrency` stepwise (Lee: 6 → 50/50,
+   ~8.5k prepare/hour). Keep SQS max concurrency ≤ Lambda reserved concurrency.
+3. Keep permit worker concurrency low (2-4); county permit portals are the fragile link.
+4. Check after every step: Lambda `Errors`/`Throttles` = 0, DLQ depth = 0, Neon insert
+   rate moving, app-level prepare failure rate not climbing.
+
+## 4. Failure handling
+
+- DLQ messages: inspect, fix root cause, redrive (`scripts/auto-fix-queue.sh`,
+  `scripts/resolve-error.sh`; error records in DynamoDB clear via `ElephantErrorResolved`).
+- If ingest silently stalls, FIRST check event source mappings are still `Enabled` — a
+  budget alarm once disabled them mid-run (`EmergencyStopEnabled` must stay `false`).
+- AccessDenied from the feeder → seeds-bucket permission missing on the worker role
+  (`SourceSeedBucketName` parameter).
+- Geo-block/outage: prepare failures spike — pause (disable mapping), restore network/VPN
+  or proxies, re-enable; SQS redelivery resumes work.
+
+## 6. Wrap-up
+
+- Feeder reports `sourceExhausted`; queues drain to 0; reconcile counts: seed rows vs
+  archived artifacts vs Neon properties vs permit-eligible vs permits loaded. Record final
+  numbers in `oracle-node/docs/<county>-county-findings.md`.
+- Commit code/docs (never data) to a `<county>-property-first-ingest` branch.

--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 elephant-cli*.log
+.redrive-logs/
 
 
 .aws-sam/

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,7 +426,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.943.0.tgz",
       "integrity": "sha512-1VvbsDSBrrvQ2UwdDab+YNpygyoDRSlOQ452KlEPh3jo155bMkiiY1siXaaXj0EMVwhPsLyKvbM4eBSl0Bi0yA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2738,7 +2737,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.79.tgz",
       "integrity": "sha512-ZLAs5YMM5N2UXN3kExMglltJrKKoW7hs3KMZFlXUnD7a5DFKBYxPFMeXA4rT+uvTxuJRZPCYX0JKI5BhyAWx4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -3052,7 +3050,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -4292,7 +4289,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
       "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5049,7 +5045,6 @@
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -5294,7 +5289,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6167,8 +6161,7 @@
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -8869,7 +8862,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -8966,7 +8958,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8999,7 +8990,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10660,7 +10650,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10802,7 +10791,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11362,7 +11350,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -11656,7 +11643,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11789,7 +11775,11 @@
         "zod": "^3.22.4"
       }
     },
-    "prepare": {},
+    "prepare": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "prepare/lambdas/downloader": {
       "name": "downloader-lambda",
       "version": "1.0.0",
@@ -11830,7 +11820,11 @@
         "@types/node": "^20.16.3"
       }
     },
-    "workflow": {},
+    "workflow": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "workflow-events/lambdas/dashboard-errors-widget": {
       "version": "1.0.0",
       "dependencies": {
@@ -12198,7 +12192,8 @@
         "@aws-sdk/client-s3": "^3.879.0",
         "@aws-sdk/client-sfn": "^3.879.0",
         "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#44fd046cfdc205a223cc7a62df5bfcaf003a395b",
-        "adm-zip": "^0.5.17"
+        "adm-zip": "^0.5.17",
+        "graceful-fs": "^4.2.11"
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.8",

--- a/prepare/template.yaml
+++ b/prepare/template.yaml
@@ -956,8 +956,8 @@ Resources:
       Runtime: nodejs22.x
       Architectures:
         - arm64
-      MemorySize: 512
-      Timeout: 300
+      MemorySize: 3008
+      Timeout: 900
       EphemeralStorage:
         Size: 2048
       CodeUri: ../workflow/lambdas/transform-worker

--- a/scripts/enqueue-palm-beach-appraisal-property-first-from-seed.mjs
+++ b/scripts/enqueue-palm-beach-appraisal-property-first-from-seed.mjs
@@ -1,0 +1,875 @@
+#!/usr/bin/env node
+
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+import { parse } from "csv-parse";
+import { readFile } from "fs/promises";
+import { Pool } from "pg";
+
+/**
+ * Palm Beach county configuration. This file is a parameterized clone of
+ * scripts/enqueue-lee-appraisal-property-first-from-seed.mjs; only the values
+ * below differ from the Lee run.
+ *
+ * The prepare state machine derives the per-county prepare queue name from the
+ * seed CSV's `county` column (lowercased, spaces -> '-', '.' removed), NOT from
+ * this object. With a seed `county` value of "Palm Beach" the state machine
+ * targets `elephant-oracle-node-prepare-queue-palm-beach`, which already exists.
+ */
+const COUNTY = {
+  /** Human-readable county name used in log lines. */
+  name: "Palm Beach",
+  /** Snake-case county key used in log message identifiers. */
+  key: "palm_beach",
+  /** Neon properties.source_system value for the Palm Beach appraiser source. */
+  sourceSystem: "palm_beach_appraiser",
+  /** Postgres application_name used for the dedup connection. */
+  applicationName: "palm-beach-appraisal-seed-enqueue",
+  /** S3 object metadata `source` tag written on each generated seed slice. */
+  seedSource: "counties-seeds-palm-beach",
+  /** Slug used in generated S3 prefixes and the default job id. */
+  slug: "palm-beach-property-first-seed",
+};
+
+/**
+ * Load a newline-delimited list of 1-based source data-row numbers into a Set.
+ * Blank lines and lines starting with '#' are ignored. Used to enqueue ONLY a
+ * specific subset of seed rows (e.g. parcels whose prepare failed) while keeping
+ * the original sourceRowNumber so outputs land in the existing row-* folders.
+ *
+ * @param {string} filePath - Path to the row-number list file.
+ * @returns {Promise<Set<number>>} Set of 1-based source data-row numbers.
+ */
+async function readOnlyRows(filePath) {
+  const content = await readFile(filePath, "utf8");
+  const rows = new Set();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const parsed = Number.parseInt(line, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--only-rows-file contains invalid row number: ${line}`);
+    }
+    rows.add(parsed);
+  }
+  if (rows.size === 0) {
+    throw new Error(`--only-rows-file ${filePath} contained no row numbers`);
+  }
+  return rows;
+}
+
+/**
+ * @typedef {object} CliOptions
+ * @property {string} sourceCsvS3Uri - Source Palm Beach county seed CSV S3 URI.
+ * @property {string} stackName - Oracle-node CloudFormation stack name.
+ * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
+ * @property {string | undefined} workflowQueueUrl - Explicit workflow starter queue URL.
+ * @property {string | undefined} propertyFirstPermitQueueUrl - Explicit property-first permit queue URL.
+ * @property {string | undefined} generatedSeedPrefix - S3 prefix for generated one-property CSV seed files.
+ * @property {string | undefined} workflowOutputBaseUri - S3 base URI for appraisal workflow outputs.
+ * @property {string | undefined} propertyFirstPermitOutputPrefix - S3 prefix consumed by the permit worker; the worker appends jobId.
+ * @property {string} jobId - Stable job identifier used for workflow messages and S3 partitioning.
+ * @property {number} limit - Maximum source rows to enqueue; 0 means all remaining source rows.
+ * @property {number} offset - Number of valid source rows to skip before enqueueing.
+ * @property {number} maxPages - Maximum Accela parcel-search pages per property.
+ * @property {number} sendDelayMs - Optional delay between SQS sends.
+ * @property {number} concurrency - Number of seed uploads/workflow SQS sends to run concurrently.
+ * @property {string} envFile - Local env file used when skipping properties already in Neon.
+ * @property {boolean} skipExistingNeon - Skip rows whose Palm Beach Appraiser property is already present in Neon.
+ * @property {boolean} dryRun - Print candidate workflow messages without uploading seeds or sending SQS messages.
+ * @property {string | undefined} onlyRowsFile - Optional path to a newline-delimited list of 1-based source data-row numbers; only those rows are enqueued. Preserves the original sourceRowNumber so re-prepared outputs land in the existing row-* folders.
+ */
+
+/**
+ * @typedef {object} ResolvedOptions
+ * @property {CliOptions} cli - Parsed CLI options.
+ * @property {string} workflowQueueUrl - Workflow starter queue URL.
+ * @property {string} propertyFirstPermitQueueUrl - Dedicated property-first permit queue URL.
+ * @property {string} generatedSeedPrefix - S3 prefix for generated one-property CSV seed files.
+ * @property {string} workflowOutputBaseUri - S3 base URI for appraisal workflow outputs.
+ * @property {string} propertyFirstPermitOutputPrefix - S3 prefix consumed by the permit worker.
+ */
+
+/**
+ * @typedef {object} S3UriParts
+ * @property {string} bucket - S3 bucket name.
+ * @property {string} key - S3 object key or prefix.
+ */
+
+/**
+ * @typedef {Record<string, string | undefined>} SeedRow
+ */
+
+/**
+ * @typedef {object} ExistingNeonIdentifiers
+ * @property {Set<string>} requestIdentifiers - Existing Palm Beach Appraiser request/Folio identifiers.
+ * @property {Set<string>} normalizedParcelIdentifiers - Existing normalized Palm Beach Appraiser parcel identifiers.
+ */
+
+/**
+ * @typedef {object} PendingUploadState
+ * @property {Set<Promise<void>>} pendingUploads - In-flight seed upload and workflow enqueue tasks.
+ * @property {Error | undefined} firstError - First asynchronous task failure seen by the scheduler.
+ */
+
+const DEFAULT_STACK_NAME = "elephant-oracle-node";
+const DEFAULT_PERMIT_STACK_NAME = "elephant-permit-harvest";
+const DEFAULT_SOURCE_CSV_S3_URI = "s3://counties-seeds/palm_beach.csv";
+const DEFAULT_ENV_FILE = "../elephant-query-db/.env.local";
+const DEFAULT_JOB_ID = `${COUNTY.slug}-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+
+const cloudFormation = new CloudFormationClient({});
+const s3 = new S3Client({});
+const sqs = new SQSClient({});
+
+/**
+ * Print CLI usage instructions.
+ *
+ * @returns {void} Writes usage text to stdout.
+ */
+function showUsage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+    node scripts/enqueue-palm-beach-appraisal-property-first-from-seed.mjs \
+      --source-csv-s3-uri s3://counties-seeds/palm_beach.csv \
+      --job-id ${COUNTY.slug}-YYYYMMDD \
+      --limit 0 --send-delay-ms 50
+
+Options:
+  --source-csv-s3-uri <s3uri>       Full Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --stack <name>                    Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
+  --permit-stack <name>             Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
+  --workflow-queue-url <url>        WorkflowQueueUrl override.
+  --property-first-permit-queue-url <url>
+                                    PropertyFirstPermitQueueUrl override.
+  --generated-seed-prefix <s3uri>   Generated one-row CSV seed prefix. Default: environment bucket / seed-inputs / job id.
+  --workflow-output-base-uri <s3uri>
+                                    Appraisal workflow output base. Default: environment bucket / outputs / ${COUNTY.slug} / job id.
+  --property-first-permit-output-prefix <s3uri>
+                                    Permit artifact prefix. Default: environment bucket / permit-harvest / ${COUNTY.slug}.
+  --job-id <id>                     Stable run id. Default: ${DEFAULT_JOB_ID}
+  --limit <number>                  Source rows to enqueue after offset; 0 means all. Default: 1000
+  --offset <number>                 Valid source rows to skip. Default: 0
+  --max-pages <number>              Max Accela pages per parcel. Default: 200
+  --send-delay-ms <number>          Delay between SQS sends. Default: 0
+  --concurrency <number>            Concurrent S3 seed uploads/SQS sends. Default: 1
+  --env-file <path>                 Env file with DATABASE_URL. Default: ${DEFAULT_ENV_FILE}
+  --include-existing-neon           Do not skip properties already present in Neon.
+  --only-rows-file <path>           Newline-delimited 1-based source data-row numbers; enqueue ONLY those rows. Preserves the original sourceRowNumber so re-prepared outputs land in the existing row-* folders. Skip count for non-listed rows is reported as skippedNotInOnlyRows.
+  --dry-run                         Print messages without uploading generated seeds or sending SQS.
+  --help                            Show this help.
+
+This script uses the S3 seed CSV as the source of truth. It writes one seed CSV
+per property so the existing appraisal workflow can extract one full property,
+then the state machine enqueues the property-first permit worker to fetch all
+Accela permits and load appraisal+permits to Neon in one transaction.
+`);
+}
+
+/**
+ * Return a trimmed string when a value is a non-empty string.
+ *
+ * @param {unknown} value - Candidate value read from CLI args, CSV, or env.
+ * @returns {string | undefined} Trimmed string when usable.
+ */
+function readOptionalString(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse a non-negative integer CLI option.
+ *
+ * @param {string} optionName - CLI option name used in diagnostics.
+ * @param {string | undefined} rawValue - Raw CLI option value.
+ * @param {number} fallback - Default value when the option is absent.
+ * @returns {number} Parsed non-negative integer.
+ */
+function parseNonNegativeInteger(optionName, rawValue, fallback) {
+  if (rawValue === undefined) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `${optionName} must be a non-negative integer, received ${rawValue}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse a positive integer CLI option.
+ *
+ * @param {string} optionName - CLI option name used in diagnostics.
+ * @param {string | undefined} rawValue - Raw CLI option value.
+ * @param {number} fallback - Default value when the option is absent.
+ * @returns {number} Parsed positive integer.
+ */
+function parsePositiveInteger(optionName, rawValue, fallback) {
+  if (rawValue === undefined) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `${optionName} must be a positive integer, received ${rawValue}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse command-line arguments into typed options.
+ *
+ * @param {string[]} argv - Raw argv excluding node and script path.
+ * @returns {CliOptions} Parsed CLI options.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      showUsage();
+      process.exit(0);
+    }
+    if (token === "--dry-run") {
+      values.dryRun = true;
+      continue;
+    }
+    if (token === "--include-existing-neon") {
+      values.includeExistingNeon = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[key] = next;
+    index += 1;
+  }
+
+  return {
+    sourceCsvS3Uri:
+      readOptionalString(values["source-csv-s3-uri"]) ??
+      DEFAULT_SOURCE_CSV_S3_URI,
+    stackName: readOptionalString(values.stack) ?? DEFAULT_STACK_NAME,
+    permitStackName:
+      readOptionalString(values["permit-stack"]) ?? DEFAULT_PERMIT_STACK_NAME,
+    workflowQueueUrl: readOptionalString(values["workflow-queue-url"]),
+    propertyFirstPermitQueueUrl: readOptionalString(
+      values["property-first-permit-queue-url"],
+    ),
+    generatedSeedPrefix: readOptionalString(values["generated-seed-prefix"]),
+    workflowOutputBaseUri: readOptionalString(
+      values["workflow-output-base-uri"],
+    ),
+    propertyFirstPermitOutputPrefix: readOptionalString(
+      values["property-first-permit-output-prefix"],
+    ),
+    jobId: readOptionalString(values["job-id"]) ?? DEFAULT_JOB_ID,
+    limit: parseNonNegativeInteger(
+      "--limit",
+      readOptionalString(values.limit),
+      1000,
+    ),
+    offset: parseNonNegativeInteger(
+      "--offset",
+      readOptionalString(values.offset),
+      0,
+    ),
+    maxPages: parsePositiveInteger(
+      "--max-pages",
+      readOptionalString(values["max-pages"]),
+      200,
+    ),
+    sendDelayMs: parseNonNegativeInteger(
+      "--send-delay-ms",
+      readOptionalString(values["send-delay-ms"]),
+      0,
+    ),
+    concurrency: parsePositiveInteger(
+      "--concurrency",
+      readOptionalString(values.concurrency),
+      1,
+    ),
+    envFile: readOptionalString(values["env-file"]) ?? DEFAULT_ENV_FILE,
+    skipExistingNeon: values.includeExistingNeon !== true,
+    onlyRowsFile: readOptionalString(values["only-rows-file"]),
+    dryRun: values.dryRun === true,
+  };
+}
+
+/**
+ * Parse an S3 URI into bucket and key components.
+ *
+ * @param {string} uri - S3 URI in `s3://bucket/key` format.
+ * @returns {S3UriParts} Parsed S3 bucket and key.
+ */
+function parseS3Uri(uri) {
+  const match = /^s3:\/\/([^/]+)\/(.*)$/i.exec(uri);
+  if (!match) throw new Error(`Invalid S3 URI: ${uri}`);
+  return { bucket: match[1], key: match[2].replace(/\/$/, "") };
+}
+
+/**
+ * Read a CloudFormation output value from a deployed stack.
+ *
+ * @param {string} stackName - CloudFormation stack name.
+ * @param {string} outputKey - Output key to find.
+ * @returns {Promise<string>} Output value.
+ */
+async function getStackOutput(stackName, outputKey) {
+  const response = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (item) => item.OutputKey === outputKey,
+  );
+  if (!output?.OutputValue) {
+    throw new Error(`Stack ${stackName} does not expose ${outputKey}`);
+  }
+  return output.OutputValue;
+}
+
+/**
+ * Build all S3 prefixes and queue URLs after reading stack outputs.
+ *
+ * @param {CliOptions} cli - Parsed CLI options.
+ * @returns {Promise<ResolvedOptions>} Fully resolved options.
+ */
+async function resolveOptions(cli) {
+  const environmentBucketName = await getStackOutput(
+    cli.stackName,
+    "EnvironmentBucketName",
+  );
+  const workflowQueueUrl =
+    cli.workflowQueueUrl ??
+    (await getStackOutput(cli.stackName, "WorkflowQueueUrl"));
+  const propertyFirstPermitQueueUrl =
+    cli.propertyFirstPermitQueueUrl ??
+    (await getStackOutput(cli.permitStackName, "PropertyFirstPermitQueueUrl"));
+  return {
+    cli,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    generatedSeedPrefix:
+      cli.generatedSeedPrefix ??
+      `s3://${environmentBucketName}/seed-inputs/${COUNTY.slug}/${cli.jobId}`,
+    workflowOutputBaseUri:
+      cli.workflowOutputBaseUri ??
+      `s3://${environmentBucketName}/outputs/${COUNTY.slug}/${cli.jobId}`,
+    propertyFirstPermitOutputPrefix:
+      cli.propertyFirstPermitOutputPrefix ??
+      `s3://${environmentBucketName}/permit-harvest/${COUNTY.slug}`,
+  };
+}
+
+/**
+ * Load simple KEY=VALUE lines from an env file without adding a dotenv dependency.
+ *
+ * Existing process.env values win, which lets callers override DATABASE_URL from
+ * the shell or CI secret injection.
+ *
+ * @param {string} envFile - Path to an env file.
+ * @returns {Promise<void>} Resolves after environment variables are populated.
+ */
+async function loadEnvFile(envFile) {
+  const content = await readFile(envFile, "utf8");
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    const rawValue = line.slice(equalsIndex + 1).trim();
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.replace(/^['"]|['"]$/g, "");
+  }
+}
+
+/**
+ * Normalize a Palm Beach parcel identifier (PCN) for duplicate checks and S3 key
+ * names.
+ *
+ * Palm Beach PCNs are 17-digit numeric strings that may arrive with separators
+ * (dots/dashes) or leading/trailing whitespace. Only non-digit characters are
+ * stripped, so distinct PCNs can never be collapsed together; separator and
+ * whitespace differences normalize away while every digit is preserved.
+ *
+ * @param {unknown} value - Raw parcel identifier.
+ * @returns {string | undefined} Digits-only parcel identifier.
+ */
+function normalizeParcelIdentifier(value) {
+  const normalized = String(value ?? "").replace(/[^0-9]/g, "");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+/**
+ * Make a string safe and compact enough for a deterministic S3 object key part.
+ *
+ * @param {unknown} value - Source value.
+ * @param {string} fallback - Fallback when source value is blank.
+ * @returns {string} S3-safe key part.
+ */
+function safeKeyPart(value, fallback) {
+  const source = readOptionalString(value) ?? fallback;
+  const safe = source
+    .replace(/[^A-Za-z0-9._=-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return safe.length > 0 ? safe.slice(0, 96) : fallback;
+}
+
+/**
+ * Escape one CSV cell according to RFC4180-style quoting rules.
+ *
+ * @param {string | undefined} value - Raw cell value.
+ * @returns {string} CSV-encoded cell.
+ */
+function encodeCsvCell(value) {
+  const text = value ?? "";
+  if (!/[",\r\n]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a one-row CSV body preserving the source header order exactly.
+ *
+ * @param {string[]} columns - Source CSV column names in order.
+ * @param {SeedRow} row - Parsed source seed row.
+ * @returns {string} One-row CSV body with header.
+ */
+function buildOneRowCsv(columns, row) {
+  return `${columns.map(encodeCsvCell).join(",")}\n${columns.map((column) => encodeCsvCell(row[column])).join(",")}\n`;
+}
+
+/**
+ * Normalize a CSV parser header row into string column names.
+ *
+ * @param {unknown[]} header - Raw header values supplied by csv-parse.
+ * @returns {string[]} Header values converted to strings.
+ */
+function normalizeCsvHeader(header) {
+  return header.map((column) => String(column));
+}
+
+/**
+ * Read existing Palm Beach Appraiser identifiers from Neon so the S3 seed file
+ * can be used to queue only new properties instead of replaying already-loaded
+ * rows.
+ *
+ * @param {CliOptions} cli - Parsed CLI options containing env-file location.
+ * @returns {Promise<ExistingNeonIdentifiers>} Existing request and parcel identifiers.
+ */
+async function readExistingNeonIdentifiers(cli) {
+  if (!cli.skipExistingNeon) {
+    return {
+      requestIdentifiers: new Set(),
+      normalizedParcelIdentifiers: new Set(),
+    };
+  }
+  await loadEnvFile(cli.envFile);
+  const databaseUrl = readOptionalString(process.env.DATABASE_URL);
+  if (databaseUrl === undefined) {
+    throw new Error(
+      `DATABASE_URL is required to skip existing Neon properties; set it or pass --include-existing-neon`,
+    );
+  }
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    application_name: COUNTY.applicationName,
+    connectionTimeoutMillis: 15_000,
+    max: 1,
+    query_timeout: 180_000,
+    statement_timeout: 180_000,
+  });
+  try {
+    const result = await pool.query(
+      `
+        select request_identifier, parcel_identifier
+        from properties
+        where source_system = $1
+      `,
+      [COUNTY.sourceSystem],
+    );
+    const requestIdentifiers = new Set();
+    const normalizedParcelIdentifiers = new Set();
+    for (const row of result.rows) {
+      const requestIdentifier = readOptionalString(row.request_identifier);
+      if (requestIdentifier !== undefined)
+        requestIdentifiers.add(requestIdentifier);
+      const parcelIdentifier = normalizeParcelIdentifier(row.parcel_identifier);
+      if (parcelIdentifier !== undefined)
+        normalizedParcelIdentifiers.add(parcelIdentifier);
+    }
+    return { requestIdentifiers, normalizedParcelIdentifiers };
+  } finally {
+    await pool.end();
+  }
+}
+
+/**
+ * Return whether a source seed row is already present in Neon.
+ *
+ * @param {SeedRow} row - Parsed source seed row.
+ * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers from Neon.
+ * @returns {boolean} True when the row should be skipped as already loaded.
+ */
+function isExistingNeonRow(row, existing) {
+  const requestIdentifier = readOptionalString(row.source_identifier);
+  if (
+    requestIdentifier !== undefined &&
+    existing.requestIdentifiers.has(requestIdentifier)
+  ) {
+    return true;
+  }
+  const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+  return (
+    parcelIdentifier !== undefined &&
+    existing.normalizedParcelIdentifiers.has(parcelIdentifier)
+  );
+}
+
+/**
+ * Return whether a value behaves like a Node readable stream.
+ *
+ * @param {unknown} value - Candidate stream value from AWS SDK S3 response body.
+ * @returns {value is NodeJS.ReadableStream} True when `pipe` is available.
+ */
+function isNodeReadableStream(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "pipe" in value &&
+    typeof (/** @type {{ pipe?: unknown }} */ (value).pipe) === "function"
+  );
+}
+
+/**
+ * Upload one generated seed CSV and enqueue its workflow starter message.
+ *
+ * @param {object} params - Upload/enqueue parameters.
+ * @param {ResolvedOptions} params.options - Resolved queue URLs and prefixes.
+ * @param {string[]} params.columns - Source CSV columns in header order.
+ * @param {SeedRow} params.row - Source seed row.
+ * @param {number} params.sourceRowNumber - One-based source CSV data row number.
+ * @param {number} params.enqueuedIndex - Zero-based index among messages selected by this run.
+ * @returns {Promise<void>} Resolves after the seed is uploaded and the workflow message is sent.
+ */
+async function uploadSeedAndEnqueueWorkflow({
+  options,
+  columns,
+  row,
+  sourceRowNumber,
+  enqueuedIndex,
+}) {
+  const seedPrefix = parseS3Uri(options.generatedSeedPrefix);
+  const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+  if (parcelIdentifier === undefined) {
+    throw new Error(
+      `Source row ${String(sourceRowNumber)} is missing parcel_id`,
+    );
+  }
+  const requestIdentifier = safeKeyPart(row.source_identifier, "unknown-folio");
+  const seedKey = `${seedPrefix.key}/row-${String(sourceRowNumber).padStart(9, "0")}-folio-${requestIdentifier}-parcel-${safeKeyPart(parcelIdentifier, "unknown-parcel")}.csv`;
+  const workflowMessage = {
+    s3: {
+      bucket: { name: seedPrefix.bucket },
+      object: { key: seedKey },
+    },
+    output_base_uri: options.workflowOutputBaseUri,
+    propertyFirstPermitQueueUrl: options.propertyFirstPermitQueueUrl,
+    propertyFirstPermitJobId: options.cli.jobId,
+    propertyFirstPermitOutputPrefix: options.propertyFirstPermitOutputPrefix,
+    propertyFirstPermitMaxPages: options.cli.maxPages,
+    sourceSeedS3Uri: options.cli.sourceCsvS3Uri,
+    sourceSeedRowNumber: sourceRowNumber,
+  };
+
+  if (options.cli.dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          enqueuedIndex,
+          sourceRowNumber,
+          county: {
+            county_name: COUNTY.name,
+            county_key: COUNTY.key,
+            source: COUNTY.seedSource,
+            parcel_identifier: parcelIdentifier,
+            request_identifier: readOptionalString(row.source_identifier),
+          },
+          seedUri: `s3://${seedPrefix.bucket}/${seedKey}`,
+          workflowMessage,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: seedPrefix.bucket,
+      Key: seedKey,
+      Body: Buffer.from(buildOneRowCsv(columns, row), "utf8"),
+      ContentType: "text/csv; charset=utf-8",
+      Metadata: {
+        source: COUNTY.seedSource,
+        jobId: options.cli.jobId,
+        sourceRowNumber: String(sourceRowNumber),
+      },
+    }),
+  );
+  const response = await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: options.workflowQueueUrl,
+      MessageBody: JSON.stringify(workflowMessage),
+    }),
+  );
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_workflow_enqueued`,
+      enqueuedIndex,
+      sourceRowNumber,
+      messageId: response.MessageId,
+      parcelIdentifier,
+      requestIdentifier: readOptionalString(row.source_identifier),
+      seedUri: `s3://${seedPrefix.bucket}/${seedKey}`,
+    }),
+  );
+}
+
+/**
+ * Wait for a fixed amount of time.
+ *
+ * @param {number} milliseconds - Delay duration.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * Normalize an unknown thrown value into an Error instance.
+ *
+ * @param {unknown} error - Value thrown by an asynchronous upload/enqueue task.
+ * @returns {Error} Error instance suitable for later rethrowing.
+ */
+function toError(error) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Schedule a seed upload/workflow enqueue task and record its eventual failure
+ * without producing an unhandled rejection while other concurrent tasks finish.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @param {Promise<void>} uploadPromise - Upload/enqueue task promise to track.
+ * @returns {void}
+ */
+function schedulePendingUpload(state, uploadPromise) {
+  /** @type {Promise<void>} */
+  let trackedPromise;
+  trackedPromise = uploadPromise
+    .catch((error) => {
+      if (state.firstError === undefined) state.firstError = toError(error);
+    })
+    .finally(() => {
+      state.pendingUploads.delete(trackedPromise);
+    });
+  state.pendingUploads.add(trackedPromise);
+}
+
+/**
+ * Wait for at least one in-flight upload/enqueue task to complete and surface
+ * any failure captured by the concurrent scheduler.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @returns {Promise<void>} Resolves after one pending task completes successfully.
+ */
+async function waitForNextPendingUpload(state) {
+  if (state.pendingUploads.size === 0) return;
+  await Promise.race(state.pendingUploads);
+  if (state.firstError !== undefined) throw state.firstError;
+}
+
+/**
+ * Wait for all scheduled upload/enqueue tasks to settle and surface the first
+ * task failure if one occurred.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @returns {Promise<void>} Resolves after all pending tasks settle successfully.
+ */
+async function waitForAllPendingUploads(state) {
+  while (state.pendingUploads.size > 0) {
+    await waitForNextPendingUpload(state);
+  }
+}
+
+/**
+ * Stream the source seed CSV, generate one-property seeds, and enqueue workflow messages.
+ *
+ * @param {ResolvedOptions} options - Fully resolved options.
+ * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers used for duplicate skips.
+ * @param {Set<number> | undefined} onlyRows - When set, only these 1-based source data-row numbers are enqueued.
+ * @returns {Promise<void>} Resolves when the requested rows have been processed.
+ */
+async function enqueueFromSeed(options, existing, onlyRows) {
+  const source = parseS3Uri(options.cli.sourceCsvS3Uri);
+  const response = await s3.send(
+    new GetObjectCommand({ Bucket: source.bucket, Key: source.key }),
+  );
+  if (!isNodeReadableStream(response.Body)) {
+    throw new Error(
+      `S3 object body is not a Node readable stream: ${options.cli.sourceCsvS3Uri}`,
+    );
+  }
+
+  /** @type {string[]} */
+  let columns = [];
+  const parser = response.Body.pipe(
+    parse({
+      columns: (header) => {
+        columns = normalizeCsvHeader(header);
+        return columns;
+      },
+      relax_column_count: true,
+      skip_empty_lines: true,
+      trim: false,
+    }),
+  );
+
+  let sourceRowNumber = 0;
+  let validRowNumber = 0;
+  let skippedExisting = 0;
+  let skippedInvalid = 0;
+  let skippedNotInOnlyRows = 0;
+  let enqueued = 0;
+  /** @type {PendingUploadState} */
+  const pendingUploadState = {
+    pendingUploads: new Set(),
+    firstError: undefined,
+  };
+
+  for await (const parsedRow of parser) {
+    if (pendingUploadState.firstError !== undefined)
+      throw pendingUploadState.firstError;
+    sourceRowNumber += 1;
+    if (onlyRows !== undefined && !onlyRows.has(sourceRowNumber)) {
+      skippedNotInOnlyRows += 1;
+      continue;
+    }
+    const row = /** @type {SeedRow} */ (parsedRow);
+    const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+    const requestIdentifier = readOptionalString(row.source_identifier);
+    if (parcelIdentifier === undefined || requestIdentifier === undefined) {
+      skippedInvalid += 1;
+      continue;
+    }
+    validRowNumber += 1;
+    if (validRowNumber <= options.cli.offset) continue;
+    if (isExistingNeonRow(row, existing)) {
+      skippedExisting += 1;
+      continue;
+    }
+    if (options.cli.limit > 0 && enqueued >= options.cli.limit) break;
+    schedulePendingUpload(
+      pendingUploadState,
+      uploadSeedAndEnqueueWorkflow({
+        options,
+        columns,
+        row,
+        sourceRowNumber,
+        enqueuedIndex: enqueued,
+      }),
+    );
+    enqueued += 1;
+    if (pendingUploadState.pendingUploads.size >= options.cli.concurrency) {
+      await waitForNextPendingUpload(pendingUploadState);
+    }
+    if (options.cli.sendDelayMs > 0) await sleep(options.cli.sendDelayMs);
+  }
+  await waitForAllPendingUploads(pendingUploadState);
+
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_seed_enqueue_complete`,
+      sourceCsvS3Uri: options.cli.sourceCsvS3Uri,
+      jobId: options.cli.jobId,
+      sourceRowsRead: sourceRowNumber,
+      validRowsSeen: validRowNumber,
+      skippedInvalid,
+      skippedExisting,
+      skippedNotInOnlyRows,
+      enqueued,
+      limit: options.cli.limit,
+      offset: options.cli.offset,
+      concurrency: options.cli.concurrency,
+      dryRun: options.cli.dryRun,
+      generatedSeedPrefix: options.generatedSeedPrefix,
+      workflowOutputBaseUri: options.workflowOutputBaseUri,
+      propertyFirstPermitOutputPrefix: options.propertyFirstPermitOutputPrefix,
+    }),
+  );
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {Promise<void>} Resolves when the enqueue run completes.
+ */
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const [options, existing, onlyRows] = await Promise.all([
+    resolveOptions(cli),
+    readExistingNeonIdentifiers(cli),
+    cli.onlyRowsFile !== undefined
+      ? readOnlyRows(cli.onlyRowsFile)
+      : Promise.resolve(undefined),
+  ]);
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_seed_enqueue_start`,
+      countyName: COUNTY.name,
+      countyKey: COUNTY.key,
+      sourceCsvS3Uri: cli.sourceCsvS3Uri,
+      jobId: cli.jobId,
+      workflowQueueUrl: options.workflowQueueUrl,
+      propertyFirstPermitQueueUrl: options.propertyFirstPermitQueueUrl,
+      skipExistingNeon: cli.skipExistingNeon,
+      existingRequestIdentifierCount: existing.requestIdentifiers.size,
+      existingParcelIdentifierCount: existing.normalizedParcelIdentifiers.size,
+      onlyRowsFile: cli.onlyRowsFile,
+      onlyRowsCount: onlyRows?.size,
+      limit: cli.limit,
+      offset: cli.offset,
+      concurrency: cli.concurrency,
+      dryRun: cli.dryRun,
+    }),
+  );
+  await enqueueFromSeed(options, existing, onlyRows);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ level: "error", message }));
+  process.exit(1);
+});

--- a/scripts/redrive-lee-transform-only.mjs
+++ b/scripts/redrive-lee-transform-only.mjs
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+/**
+ * redrive-lee-transform-only.mjs
+ *
+ * Checkpointed transform-only redrive driver for the Lee County
+ * lee-fullcounty-20260619 job.
+ *
+ * Enumerates every row-* folder that has output.zip (prepare done) but has no
+ * <uuid>/transformed_output.zip (transform missing), then direct-invokes the
+ * TransformWorkerFunction for each parcel with concurrency control.
+ *
+ * Usage:
+ *   AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+ *     node scripts/redrive-lee-transform-only.mjs --dry-run
+ *
+ *   # Live test — 20 parcels
+ *   AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+ *     node scripts/redrive-lee-transform-only.mjs --limit 20
+ *
+ *   # Full run (detached, log to .redrive-logs/)
+ *   nohup env AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+ *     node scripts/redrive-lee-transform-only.mjs \
+ *     > .redrive-logs/transform-redrive.log 2>&1 &
+ */
+import { fileURLToPath } from "url";
+import { randomUUID } from "crypto";
+import {
+  S3Client,
+  ListObjectsV2Command,
+  HeadObjectCommand,
+  PutObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_REGION = process.env.AWS_REGION ?? "us-east-1";
+const DEFAULT_BUCKET = "elephant-oracle-node-environmentbucket-mmsoo3xbdi80";
+const DEFAULT_JOB_ID = "lee-fullcounty-20260619";
+const DEFAULT_CONCURRENCY = 100;
+const DEFAULT_CHECKPOINT_EVERY = 50;
+const DEFAULT_TRANSFORM_FUNCTION =
+  "elephant-oracle-node-TransformWorkerFunction-LLr08PR6lyg3";
+
+const DEFAULT_OUTPUTS_PREFIX = `outputs/lee-property-first-seed/${DEFAULT_JOB_ID}`;
+const DEFAULT_STATE_S3_URI = `s3://${DEFAULT_BUCKET}/permit-harvest/${DEFAULT_JOB_ID}/transform-redrive-state.json`;
+
+const COUNTY = "Lee";
+
+// ---------------------------------------------------------------------------
+// AWS clients
+// ---------------------------------------------------------------------------
+
+const s3 = new S3Client({ region: DEFAULT_REGION });
+const lambda = new LambdaClient({ region: DEFAULT_REGION });
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function usage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \\
+    node scripts/redrive-lee-transform-only.mjs [options]
+
+Options:
+  --bucket <name>          S3 bucket. Default: ${DEFAULT_BUCKET}
+  --job-id <id>            Job id prefix. Default: ${DEFAULT_JOB_ID}
+  --transform-fn <name>    Lambda function name/ARN. Default: ${DEFAULT_TRANSFORM_FUNCTION}
+  --state-s3-uri <uri>     Checkpoint S3 URI. Default: ${DEFAULT_STATE_S3_URI}
+  --concurrency <n>        Max parallel Lambda invocations. Default: ${DEFAULT_CONCURRENCY}
+  --limit <n>              Stop after N parcels (0 = unlimited). Default: 0
+  --checkpoint-every <n>   Write checkpoint every N completed parcels. Default: ${DEFAULT_CHECKPOINT_EVERY}
+  --dry-run                Enumerate targets without invoking Lambda.
+  --reset-checkpoint       Ignore existing checkpoint and start from the beginning.
+  --help                   Show this help.
+`);
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (
+      token === "--dry-run" ||
+      token === "--reset-checkpoint"
+    ) {
+      values[token.slice(2)] = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[token.slice(2)] = next;
+    i += 1;
+  }
+
+  const jobId = String(values["job-id"] ?? DEFAULT_JOB_ID);
+  const bucket = String(values.bucket ?? DEFAULT_BUCKET);
+
+  return {
+    bucket,
+    jobId,
+    outputsPrefix: `outputs/lee-property-first-seed/${jobId}`,
+    transformFn: String(values["transform-fn"] ?? DEFAULT_TRANSFORM_FUNCTION),
+    stateS3Uri: String(
+      values["state-s3-uri"] ??
+        `s3://${bucket}/permit-harvest/${jobId}/transform-redrive-state.json`,
+    ),
+    concurrency: parseInteger(
+      values.concurrency,
+      DEFAULT_CONCURRENCY,
+      "--concurrency",
+      1,
+    ),
+    limit: parseInteger(values.limit, 0, "--limit", 0),
+    checkpointEvery: parseInteger(
+      values["checkpoint-every"],
+      DEFAULT_CHECKPOINT_EVERY,
+      "--checkpoint-every",
+      1,
+    ),
+    dryRun: values["dry-run"] === true,
+    resetCheckpoint: values["reset-checkpoint"] === true,
+  };
+}
+
+function parseInteger(raw, fallback, name, min) {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed) || parsed < min) {
+    throw new Error(`${name} must be an integer >= ${min}`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// S3 helpers
+// ---------------------------------------------------------------------------
+
+function parseS3Uri(uri) {
+  const match = /^s3:\/\/([^/]+)\/(.+)$/i.exec(uri);
+  if (!match) throw new Error(`Invalid S3 URI: ${uri}`);
+  return { bucket: match[1], key: match[2].replace(/\/$/, "") };
+}
+
+async function objectExists(bucket, key) {
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch (error) {
+    const status = error?.$metadata?.httpStatusCode;
+    if (
+      status === 404 ||
+      error?.name === "NoSuchKey" ||
+      error?.name === "NotFound"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function putJson(bucket, key, data) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: JSON.stringify({ ...data, updatedAt: new Date().toISOString() }, null, 2),
+      ContentType: "application/json; charset=utf-8",
+    }),
+  );
+}
+
+async function getJson(bucket, key) {
+  const response = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const body = await response.Body?.transformToString();
+  if (body === undefined) throw new Error(`Empty S3 body: s3://${bucket}/${key}`);
+  return JSON.parse(body);
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint
+// ---------------------------------------------------------------------------
+
+const SCHEMA_VERSION = "oracle-node.lee-transform-only-redrive.v1";
+
+function createInitialCheckpoint() {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    // Set of row-folder keys that are done (written as JSON array for portability)
+    doneRows: [],
+    processedCount: 0,
+    succeededCount: 0,
+    failedCount: 0,
+    verifiedCount: 0,
+    failures: [],
+  };
+}
+
+async function readCheckpoint(stateS3Uri, resetCheckpoint) {
+  const { bucket, key } = parseS3Uri(stateS3Uri);
+  if (resetCheckpoint || !(await objectExists(bucket, key))) {
+    return createInitialCheckpoint();
+  }
+  const raw = await getJson(bucket, key);
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    doneRows: Array.isArray(raw.doneRows) ? raw.doneRows : [],
+    processedCount: Number.isFinite(raw.processedCount) ? raw.processedCount : 0,
+    succeededCount: Number.isFinite(raw.succeededCount) ? raw.succeededCount : 0,
+    failedCount: Number.isFinite(raw.failedCount) ? raw.failedCount : 0,
+    verifiedCount: Number.isFinite(raw.verifiedCount) ? raw.verifiedCount : 0,
+    failures: Array.isArray(raw.failures) ? raw.failures.slice(-200) : [],
+  };
+}
+
+async function writeCheckpoint(stateS3Uri, state) {
+  const { bucket, key } = parseS3Uri(stateS3Uri);
+  await putJson(bucket, key, state);
+}
+
+// ---------------------------------------------------------------------------
+// Target enumeration
+// ---------------------------------------------------------------------------
+
+/**
+ * List all row-folder prefixes under outputsPrefix that contain output.zip
+ * but have no <uuid>/transformed_output.zip.
+ *
+ * Strategy: flat S3 listing of all keys under the prefix, then group by row folder,
+ * classify each row folder, and return the targets.
+ *
+ * Authoritative count — this is the single source of truth for what needs redrive.
+ */
+async function enumerateTargets(bucket, outputsPrefix, doneRowSet) {
+  const prefix = `${outputsPrefix}/`;
+  let continuationToken = undefined;
+
+  // row key -> { hasOutputZip, hasTransformedOutputZip }
+  const rows = new Map();
+
+  let pageCount = 0;
+  console.log(`Enumerating S3 keys under s3://${bucket}/${prefix} ...`);
+
+  do {
+    const response = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    for (const obj of response.Contents ?? []) {
+      const key = obj.Key;
+      if (!key) continue;
+
+      // Extract row folder: first path segment after the prefix
+      // e.g. outputs/.../row-000001-folio-xxx-parcel-yyy/...
+      const relative = key.slice(prefix.length);
+      const slashIdx = relative.indexOf("/");
+      if (slashIdx === -1) continue; // top-level file, skip
+      const rowFolder = relative.slice(0, slashIdx);
+      const rest = relative.slice(slashIdx + 1);
+
+      if (!rows.has(rowFolder)) {
+        rows.set(rowFolder, { hasOutputZip: false, hasTransformedOutputZip: false });
+      }
+      const entry = rows.get(rowFolder);
+
+      if (rest === "output.zip") {
+        entry.hasOutputZip = true;
+      }
+      // transformed_output.zip is nested one UUID level deep: <uuid>/transformed_output.zip
+      if (rest.endsWith("/transformed_output.zip")) {
+        entry.hasTransformedOutputZip = true;
+      }
+    }
+
+    pageCount += 1;
+    if (pageCount % 50 === 0) {
+      console.log(`  ... ${pageCount} pages scanned, ${rows.size} row folders seen so far`);
+    }
+
+    continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+  } while (continuationToken !== undefined);
+
+  console.log(`Enumeration complete: ${rows.size} total row folders across ${pageCount} pages`);
+
+  const targets = [];
+  for (const [rowFolder, { hasOutputZip, hasTransformedOutputZip }] of rows) {
+    if (hasOutputZip && !hasTransformedOutputZip) {
+      if (!doneRowSet.has(rowFolder)) {
+        targets.push(rowFolder);
+      }
+    }
+  }
+
+  return targets;
+}
+
+// ---------------------------------------------------------------------------
+// Lambda invocation
+// ---------------------------------------------------------------------------
+
+/**
+ * Direct-invoke the transform worker for a single row folder.
+ * Returns the execution id used so the caller can verify the output.
+ */
+async function invokeTransform(bucket, outputsPrefix, rowFolder, transformFn) {
+  const executionId = randomUUID();
+  const inputS3Uri = `s3://${bucket}/${outputsPrefix}/${rowFolder}/output.zip`;
+  const outputPrefix = `s3://${bucket}/${outputsPrefix}/${rowFolder}`;
+
+  const payload = {
+    inputS3Uri,
+    county: COUNTY,
+    outputPrefix,
+    executionId,
+    directInvocation: true,
+  };
+
+  const response = await lambda.send(
+    new InvokeCommand({
+      FunctionName: transformFn,
+      InvocationType: "RequestResponse",
+      Payload: JSON.stringify(payload),
+    }),
+  );
+
+  if (response.FunctionError) {
+    const errorPayload = JSON.parse(
+      new TextDecoder().decode(response.Payload ?? new Uint8Array()),
+    );
+    throw new Error(
+      `Lambda FunctionError: ${errorPayload.errorMessage || errorPayload.errorType || JSON.stringify(errorPayload)}`,
+    );
+  }
+
+  const result = JSON.parse(
+    new TextDecoder().decode(response.Payload ?? new Uint8Array()),
+  );
+
+  return { executionId, result };
+}
+
+/**
+ * Verify that transformed_output.zip was written for the given row folder.
+ * The transform worker writes to <outputPrefix>/<executionId>/transformed_output.zip.
+ */
+async function verifyTransformOutput(bucket, outputsPrefix, rowFolder, executionId) {
+  const key = `${outputsPrefix}/${rowFolder}/${executionId}/transformed_output.zip`;
+  return objectExists(bucket, key);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency pool
+// ---------------------------------------------------------------------------
+
+/**
+ * Process an array of tasks with a bounded concurrency pool.
+ * Each task is a zero-arg async function. Results are collected in order.
+ */
+async function runWithConcurrency(tasks, concurrency, onComplete) {
+  const results = [];
+  let index = 0;
+
+  async function worker() {
+    while (index < tasks.length) {
+      const i = index++;
+      try {
+        const result = await tasks[i]();
+        results[i] = { ok: true, value: result };
+      } catch (error) {
+        results[i] = {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+      if (onComplete) onComplete(i, results[i]);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, () =>
+    worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: options.dryRun ? "dry-run" : "live",
+        bucket: options.bucket,
+        jobId: options.jobId,
+        outputsPrefix: options.outputsPrefix,
+        transformFn: options.transformFn,
+        stateS3Uri: options.stateS3Uri,
+        concurrency: options.concurrency,
+        limit: options.limit,
+        checkpointEvery: options.checkpointEvery,
+        resetCheckpoint: options.resetCheckpoint,
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Load checkpoint
+  const state = await readCheckpoint(options.stateS3Uri, options.resetCheckpoint);
+  const doneRowSet = new Set(state.doneRows);
+  console.log(
+    `Checkpoint loaded: ${doneRowSet.size} already done, ${state.processedCount} total processed so far`,
+  );
+
+  // Enumerate targets
+  const allTargets = await enumerateTargets(
+    options.bucket,
+    options.outputsPrefix,
+    doneRowSet,
+  );
+  console.log(`Targets remaining (output.zip present, no transformed_output.zip, not done): ${allTargets.length}`);
+
+  if (options.dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          targetsRemaining: allTargets.length,
+          alreadyDone: doneRowSet.size,
+          checkpointUri: options.stateS3Uri,
+          estimatedDurationHours:
+            Math.ceil((allTargets.length * 30) / options.concurrency / 3600 * 10) / 10,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  // Apply --limit
+  const targets =
+    options.limit > 0 ? allTargets.slice(0, options.limit) : allTargets;
+  console.log(`Will process ${targets.length} parcels at concurrency ${options.concurrency}`);
+
+  let completedCount = 0;
+
+  const tasks = targets.map((rowFolder) => async () => {
+    const { executionId } = await invokeTransform(
+      options.bucket,
+      options.outputsPrefix,
+      rowFolder,
+      options.transformFn,
+    );
+
+    const verified = await verifyTransformOutput(
+      options.bucket,
+      options.outputsPrefix,
+      rowFolder,
+      executionId,
+    );
+
+    return { rowFolder, executionId, verified };
+  });
+
+  // Process with concurrency pool, updating checkpoint as we go
+  const results = await runWithConcurrency(
+    tasks,
+    options.concurrency,
+    async (taskIndex, result) => {
+      const rowFolder = targets[taskIndex];
+      completedCount += 1;
+
+      if (result.ok) {
+        const { verified } = result.value;
+        state.doneRows.push(rowFolder);
+        state.processedCount += 1;
+        state.succeededCount += 1;
+        if (verified) state.verifiedCount += 1;
+
+        if (completedCount % 100 === 0) {
+          console.log(
+            `[${completedCount}/${targets.length}] ok row=${rowFolder} verified=${verified}`,
+          );
+        }
+      } else {
+        state.processedCount += 1;
+        state.failedCount += 1;
+        state.failures = [
+          ...state.failures,
+          { rowFolder, error: result.error, at: new Date().toISOString() },
+        ].slice(-200);
+        console.error(`[${completedCount}/${targets.length}] FAIL row=${rowFolder} error=${result.error}`);
+      }
+
+      if (completedCount % options.checkpointEvery === 0) {
+        await writeCheckpoint(options.stateS3Uri, state);
+      }
+    },
+  );
+
+  // Final checkpoint
+  await writeCheckpoint(options.stateS3Uri, state);
+
+  const succeeded = results.filter((r) => r.ok).length;
+  const failed = results.filter((r) => !r.ok).length;
+  const verified = results.filter((r) => r.ok && r.value.verified).length;
+
+  const summary = {
+    targetsAttempted: targets.length,
+    succeeded,
+    failed,
+    verified,
+    unverified: succeeded - verified,
+    checkpointUri: options.stateS3Uri,
+    failures: state.failures.slice(-20),
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/send-palm-beach-seed-feeder.mjs
+++ b/scripts/send-palm-beach-seed-feeder.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  GetQueueUrlCommand,
+  SendMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+
+/**
+ * Palm Beach property-first seed-feeder sender.
+ *
+ * Builds and sends ONE Palm Beach feeder message to the permit-harvest queue.
+ * The feeder is the self-requeuing full-run trigger: it drips the whole Palm
+ * Beach seed CSV through the appraisal -> permit pipeline with backpressure,
+ * checkpointing progress in S3 and rescheduling itself with an SQS delay until
+ * the county is exhausted.
+ *
+ * Queue URLs and the environment bucket are resolved from the same
+ * CloudFormation stacks the enqueue scripts use. Per-parcel workflow routing is
+ * derived by the prepare state machine from the seed CSV's `county` column
+ * (-> `elephant-oracle-node-prepare-queue-palm-beach`), not from this message.
+ */
+const COUNTY = {
+  /** Feeder message discriminator routed by the permit-harvest worker. */
+  feederType: "palm-beach-property-first-seed-feeder",
+  /** Neon properties.source_system used by the worker's skipExistingNeon dedup. */
+  sourceSystem: "palm_beach_appraiser",
+  /** Slug used for generated S3 prefixes so the loader prefix is predictable. */
+  slug: "palm-beach-property-first-seed",
+  /** Per-county prepare queue name resolved for backpressure. */
+  prepareQueueName: "elephant-oracle-node-prepare-queue-palm-beach",
+};
+
+const DEFAULT_STACK_NAME = "elephant-oracle-node";
+const DEFAULT_PERMIT_STACK_NAME = "elephant-permit-harvest";
+const DEFAULT_SOURCE_CSV_S3_URI = "s3://counties-seeds/palm_beach.csv";
+const DEFAULT_JOB_ID = `palm-beach-property-first-seed-all-${new Date()
+  .toISOString()
+  .slice(0, 10)
+  .replace(/-/g, "")}`;
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_REQUEUE_DELAY_SECONDS = 900;
+const DEFAULT_WORKFLOW_MAX_MESSAGES = 250;
+const DEFAULT_PREPARE_MAX_MESSAGES = 5000;
+
+const cloudFormation = new CloudFormationClient({});
+const sqs = new SQSClient({});
+
+/**
+ * @typedef {object} CliOptions
+ * @property {string} stackName - Oracle-node CloudFormation stack name.
+ * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
+ * @property {string} sourceCsvS3Uri - Palm Beach seed CSV S3 URI.
+ * @property {string} jobId - Stable run identifier used for S3 partitioning.
+ * @property {boolean} dryRun - Print the feeder message without sending it.
+ */
+
+/**
+ * Print CLI usage instructions.
+ *
+ * @returns {void} Writes usage text to stdout.
+ */
+function showUsage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+    node scripts/send-palm-beach-seed-feeder.mjs [--dry-run] [--job-id <id>]
+
+Options:
+  --stack <name>          Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
+  --permit-stack <name>   Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
+  --source-csv-s3-uri <s3uri>
+                          Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --job-id <id>           Stable run id. Default: ${DEFAULT_JOB_ID}
+  --dry-run               Print the feeder message JSON without sending to SQS.
+  --help                  Show this help.
+
+Sends ONE feeder message to the permit-harvest queue. The worker then self-
+requeues, dripping the whole Palm Beach seed through the pipeline with workflow
+and prepare backpressure until the county is exhausted.
+`);
+}
+
+/**
+ * Return a trimmed string when a value is a non-empty string.
+ *
+ * @param {string | undefined} value - Candidate CLI value.
+ * @returns {string | undefined} Trimmed string when usable.
+ */
+function readOptionalString(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse command-line arguments into typed options.
+ *
+ * @param {string[]} argv - Raw argv excluding node and script path.
+ * @returns {CliOptions} Parsed CLI options.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      showUsage();
+      process.exit(0);
+    }
+    if (token === "--dry-run") {
+      values.dryRun = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[key] = next;
+    index += 1;
+  }
+
+  return {
+    stackName: readOptionalString(values.stack) ?? DEFAULT_STACK_NAME,
+    permitStackName:
+      readOptionalString(values["permit-stack"]) ?? DEFAULT_PERMIT_STACK_NAME,
+    sourceCsvS3Uri:
+      readOptionalString(values["source-csv-s3-uri"]) ??
+      DEFAULT_SOURCE_CSV_S3_URI,
+    jobId: readOptionalString(values["job-id"]) ?? DEFAULT_JOB_ID,
+    dryRun: values.dryRun === true,
+  };
+}
+
+/**
+ * Read a CloudFormation output value from a deployed stack.
+ *
+ * @param {string} stackName - CloudFormation stack name.
+ * @param {string} outputKey - Output key to find.
+ * @returns {Promise<string>} Output value.
+ */
+async function getStackOutput(stackName, outputKey) {
+  const response = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (item) => item.OutputKey === outputKey,
+  );
+  if (!output?.OutputValue) {
+    throw new Error(`Stack ${stackName} does not expose ${outputKey}`);
+  }
+  return output.OutputValue;
+}
+
+/**
+ * Resolve an SQS queue URL from its name.
+ *
+ * @param {string} queueName - SQS queue name.
+ * @returns {Promise<string>} Queue URL.
+ */
+async function getQueueUrl(queueName) {
+  const response = await sqs.send(
+    new GetQueueUrlCommand({ QueueName: queueName }),
+  );
+  if (!response.QueueUrl) {
+    throw new Error(`Could not resolve queue URL for ${queueName}`);
+  }
+  return response.QueueUrl;
+}
+
+/**
+ * Build the Palm Beach property-first seed-feeder message from resolved infra.
+ *
+ * @param {object} params - Message build parameters.
+ * @param {CliOptions} params.cli - Parsed CLI options.
+ * @param {string} params.environmentBucketName - Output/seed/state S3 bucket name.
+ * @param {string} params.workflowQueueUrl - Appraisal workflow starter queue URL.
+ * @param {string} params.propertyFirstPermitQueueUrl - Property-first permit queue URL.
+ * @param {string} params.feederQueueUrl - Permit-harvest queue the feeder reschedules onto.
+ * @param {string} params.prepareQueueUrl - Palm Beach prepare queue URL for backpressure.
+ * @returns {Record<string, unknown>} Feeder message body.
+ */
+function buildFeederMessage({
+  cli,
+  environmentBucketName,
+  workflowQueueUrl,
+  propertyFirstPermitQueueUrl,
+  feederQueueUrl,
+  prepareQueueUrl,
+}) {
+  return {
+    type: COUNTY.feederType,
+    version: 1,
+    sourceSystem: COUNTY.sourceSystem,
+    jobId: cli.jobId,
+    sourceCsvS3Uri: cli.sourceCsvS3Uri,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    generatedSeedPrefix: `s3://${environmentBucketName}/seed-inputs/${COUNTY.slug}/${cli.jobId}`,
+    workflowOutputBaseUri: `s3://${environmentBucketName}/outputs/${COUNTY.slug}/${cli.jobId}`,
+    propertyFirstPermitOutputPrefix: `s3://${environmentBucketName}/permit-harvest/${COUNTY.slug}`,
+    stateS3Uri: `s3://${environmentBucketName}/permit-harvest/${cli.jobId}/feeder-state.json`,
+    batchSize: DEFAULT_BATCH_SIZE,
+    requeueDelaySeconds: DEFAULT_REQUEUE_DELAY_SECONDS,
+    backpressureQueues: [
+      {
+        name: "workflow",
+        queueUrl: workflowQueueUrl,
+        maxMessages: DEFAULT_WORKFLOW_MAX_MESSAGES,
+      },
+      {
+        name: "prepare",
+        queueUrl: prepareQueueUrl,
+        maxMessages: DEFAULT_PREPARE_MAX_MESSAGES,
+      },
+    ],
+  };
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {Promise<void>} Resolves after the feeder message is printed or sent.
+ */
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const [
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    prepareQueueUrl,
+  ] = await Promise.all([
+    getStackOutput(cli.stackName, "EnvironmentBucketName"),
+    getStackOutput(cli.stackName, "WorkflowQueueUrl"),
+    getStackOutput(cli.permitStackName, "PropertyFirstPermitQueueUrl"),
+    getStackOutput(cli.permitStackName, "PermitHarvestQueueUrl"),
+    getQueueUrl(COUNTY.prepareQueueName),
+  ]);
+
+  const feederMessage = buildFeederMessage({
+    cli,
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    prepareQueueUrl,
+  });
+
+  if (cli.dryRun) {
+    console.log(
+      JSON.stringify(
+        { dryRun: true, feederQueueUrl, feederMessage },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const response = await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: feederQueueUrl,
+      MessageBody: JSON.stringify(feederMessage),
+    }),
+  );
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: "palm_beach_property_first_seed_feeder_sent",
+      jobId: cli.jobId,
+      feederQueueUrl,
+      messageId: response.MessageId,
+    }),
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ level: "error", message }));
+  process.exit(1);
+});

--- a/workflow/lambdas/permit-harvest-worker/index.mjs
+++ b/workflow/lambdas/permit-harvest-worker/index.mjs
@@ -105,11 +105,17 @@ import {
  */
 
 /**
- * @typedef {object} LeePropertyFirstSeedFeederMessage
- * @property {"lee-property-first-seed-feeder"} type - Message discriminator.
+ * County-generic property-first seed feeder message. The handler routes any
+ * message whose `type` matches `<county-slug>-property-first-seed-feeder` (e.g.
+ * `lee-property-first-seed-feeder`, `palm-beach-property-first-seed-feeder`)
+ * through the same config-driven feeder; per-parcel workflow routing comes from
+ * the seed CSV's `county` column, not this message.
+ *
+ * @typedef {object} PropertyFirstSeedFeederMessage
+ * @property {"lee-property-first-seed-feeder"} type - Canonical discriminant kept as a literal so the `PermitHarvestMessage` union still narrows; at runtime the handler routes any `<county-slug>-property-first-seed-feeder` type (see `isPropertyFirstSeedFeederType`).
  * @property {1} version - Message version.
  * @property {string} jobId - Stable job identifier shared by generated appraisal workflow messages.
- * @property {string} sourceCsvS3Uri - Lee county seed CSV S3 URI.
+ * @property {string} sourceCsvS3Uri - County seed CSV S3 URI.
  * @property {string} workflowQueueUrl - Existing appraisal workflow starter queue URL.
  * @property {string} propertyFirstPermitQueueUrl - Existing property-first permit queue URL, passed into appraisal workflow messages.
  * @property {string} feederQueueUrl - Queue URL where the feeder reschedules itself with an SQS delay.
@@ -117,12 +123,20 @@ import {
  * @property {string} workflowOutputBaseUri - S3 base URI for appraisal workflow outputs.
  * @property {string} propertyFirstPermitOutputPrefix - S3 prefix consumed by property-first permit workers; worker appends jobId.
  * @property {string} stateS3Uri - S3 JSON state/checkpoint URI used to resume the next source row.
+ * @property {string | undefined} [sourceSystem] - Neon `properties.source_system` value used by the `skipExistingNeon` dedup. Defaults to `lee_appraiser` for backward compatibility.
  * @property {LeePropertyFirstSeedBackpressureQueue[] | undefined} [backpressureQueues] - Queues that must be below their thresholds before enqueueing more work.
  * @property {number | undefined} [batchSize] - Maximum new source rows to enqueue during one feeder wakeup.
  * @property {number | undefined} [maxPages] - Maximum Accela parcel-search pages per property.
  * @property {number | undefined} [requeueDelaySeconds] - SQS delay before the next feeder wakeup.
  * @property {number | undefined} [sendDelayMs] - Optional delay between workflow SQS sends.
- * @property {boolean | undefined} [skipExistingNeon] - Skip source rows already loaded from Lee Appraiser into Neon. Defaults true.
+ * @property {boolean | undefined} [skipExistingNeon] - Skip source rows already loaded for this `sourceSystem` into Neon. Defaults true.
+ */
+
+/**
+ * Backward-compatible alias for {@link PropertyFirstSeedFeederMessage}; other
+ * code and JSDoc still reference the original Lee-specific name.
+ *
+ * @typedef {PropertyFirstSeedFeederMessage} LeePropertyFirstSeedFeederMessage
  */
 
 /**
@@ -168,7 +182,7 @@ import {
 
 /**
  * @typedef {object} LeePropertyFirstSeedFeederState
- * @property {"permit-harvest.lee-property-first-seed-feeder-state.v1"} schemaVersion - State schema marker.
+ * @property {"permit-harvest.property-first-seed-feeder-state.v2" | "permit-harvest.lee-property-first-seed-feeder-state.v1"} schemaVersion - State schema marker (v2 generic; v1 legacy Lee, accepted on read).
  * @property {string} jobId - Job identifier associated with the checkpoint.
  * @property {string} sourceCsvS3Uri - Source seed CSV associated with the checkpoint.
  * @property {number} nextSourceRowNumber - One-based CSV data row number to inspect on the next wakeup.
@@ -283,6 +297,53 @@ const DEFAULT_LEE_PROPERTY_FIRST_SEED_BATCH_SIZE = 100;
 const DEFAULT_LEE_PROPERTY_FIRST_SEED_MAX_PAGES = 200;
 const DEFAULT_LEE_PROPERTY_FIRST_SEED_REQUEUE_DELAY_SECONDS = 900;
 const MAX_SQS_DELAY_SECONDS = 900;
+/** County-generic feeder checkpoint schema written by this worker. */
+const PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION =
+  "permit-harvest.property-first-seed-feeder-state.v2";
+/** Legacy Lee-specific checkpoint schema still accepted on read for resume. */
+const LEGACY_LEE_PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION =
+  "permit-harvest.lee-property-first-seed-feeder-state.v1";
+/** Default Neon source_system used when a feeder message omits sourceSystem. */
+const DEFAULT_PROPERTY_FIRST_SEED_FEEDER_SOURCE_SYSTEM = "lee_appraiser";
+/** Matches `<county-slug>-property-first-seed-feeder` message discriminators. */
+const PROPERTY_FIRST_SEED_FEEDER_TYPE_PATTERN =
+  /^[a-z0-9-]+-property-first-seed-feeder$/;
+
+/**
+ * Return true when a message `type` is a property-first seed feeder discriminator.
+ *
+ * @param {unknown} type - Candidate message type.
+ * @returns {boolean} True for any `<county-slug>-property-first-seed-feeder` type.
+ */
+function isPropertyFirstSeedFeederType(type) {
+  return (
+    typeof type === "string" &&
+    PROPERTY_FIRST_SEED_FEEDER_TYPE_PATTERN.test(type)
+  );
+}
+
+/**
+ * Narrow a validated permit-harvest message to a property-first seed feeder.
+ *
+ * @param {PermitHarvestMessage} message - Validated permit-harvest message.
+ * @returns {message is LeePropertyFirstSeedFeederMessage} True for feeder messages.
+ */
+function isPropertyFirstSeedFeederMessage(message) {
+  return isPropertyFirstSeedFeederType(message.type);
+}
+
+/**
+ * Resolve the Neon `properties.source_system` used for feeder dedup.
+ *
+ * @param {PropertyFirstSeedFeederMessage} message - Feeder message.
+ * @returns {string} Source system, defaulting to Lee for backward compatibility.
+ */
+function resolveFeederSourceSystem(message) {
+  return (
+    readOptionalString(message.sourceSystem) ??
+    DEFAULT_PROPERTY_FIRST_SEED_FEEDER_SOURCE_SYSTEM
+  );
+}
 const DEFAULT_PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES = [
   "AutoSalesRepair",
   "Commercial",
@@ -299,6 +360,7 @@ const DEFAULT_PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES = [
   "ShoppingCenterRegional",
   "Supermarket",
 ];
+const ALL_PROPERTY_FIRST_PERMIT_USAGE_TYPES_SENTINEL = "__ALL__";
 
 const APPRAISAL_TABLE_ORDER = [
   "unnormalized_addresses",
@@ -532,6 +594,20 @@ function normalizePropertyUsageTypeKey(propertyUsageType) {
 }
 
 /**
+ * Return true when the configured permit coverage scope should include every appraiser usage type.
+ *
+ * @param {string[]} eligibleUsageTypes - Parsed eligible usage type configuration.
+ * @returns {boolean} True when full property-first permit coverage is enabled.
+ */
+function isFullPropertyFirstPermitCoverageEnabled(eligibleUsageTypes) {
+  return eligibleUsageTypes.some(
+    (usageType) =>
+      usageType.trim().toUpperCase() ===
+      ALL_PROPERTY_FIRST_PERMIT_USAGE_TYPES_SENTINEL,
+  );
+}
+
+/**
  * Build the permit-routing decision from an already-resolved appraiser usage type.
  *
  * @param {object} params - Routing-decision parameters.
@@ -552,8 +628,9 @@ function buildPropertyFirstPermitEligibility({
   );
   const propertyUsageTypeKey = normalizePropertyUsageTypeKey(propertyUsageType);
   const shouldEnqueue =
-    propertyUsageTypeKey !== null &&
-    eligibleUsageTypeKeys.has(propertyUsageTypeKey);
+    isFullPropertyFirstPermitCoverageEnabled(eligibleUsageTypes) ||
+    (propertyUsageTypeKey !== null &&
+      eligibleUsageTypeKeys.has(propertyUsageTypeKey));
   const reason = shouldEnqueue
     ? "eligible_property_usage_type"
     : readError !== null
@@ -1125,7 +1202,7 @@ function isMissingS3ObjectError(error) {
  */
 function createInitialLeePropertyFirstSeedFeederState(message) {
   return {
-    schemaVersion: "permit-harvest.lee-property-first-seed-feeder-state.v1",
+    schemaVersion: PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION,
     jobId: message.jobId,
     sourceCsvS3Uri: message.sourceCsvS3Uri,
     nextSourceRowNumber: 1,
@@ -1154,7 +1231,9 @@ async function readLeePropertyFirstSeedFeederState(message) {
     }
     if (
       parsed.schemaVersion !==
-      "permit-harvest.lee-property-first-seed-feeder-state.v1"
+        PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION &&
+      parsed.schemaVersion !==
+        LEGACY_LEE_PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION
     ) {
       throw new Error(
         `Unsupported seed feeder state schema: ${String(parsed.schemaVersion)}`,
@@ -1167,7 +1246,7 @@ async function readLeePropertyFirstSeedFeederState(message) {
         ? Math.trunc(parsed.nextSourceRowNumber)
         : 1;
     return {
-      schemaVersion: "permit-harvest.lee-property-first-seed-feeder-state.v1",
+      schemaVersion: PROPERTY_FIRST_SEED_FEEDER_STATE_SCHEMA_VERSION,
       jobId: readOptionalString(parsed.jobId) ?? message.jobId,
       sourceCsvS3Uri:
         readOptionalString(parsed.sourceCsvS3Uri) ?? message.sourceCsvS3Uri,
@@ -1218,13 +1297,17 @@ async function writeLeePropertyFirstSeedFeederState(message, state) {
 }
 
 /**
- * Read existing Lee Appraiser identifiers from Neon so the feeder does not queue
- * properties already loaded by earlier runs.
+ * Read existing appraiser identifiers from Neon so the feeder does not queue
+ * properties already loaded by earlier runs for the same source system.
  *
  * @param {boolean} skipExistingNeon - Whether to query Neon for existing identifiers.
+ * @param {string} sourceSystem - Neon `properties.source_system` to dedup against.
  * @returns {Promise<ExistingLeeAppraiserIdentifiers>} Existing request and parcel identifiers.
  */
-async function readExistingLeeAppraiserIdentifiers(skipExistingNeon) {
+async function readExistingLeeAppraiserIdentifiers(
+  skipExistingNeon,
+  sourceSystem,
+) {
   if (!skipExistingNeon) {
     return {
       requestIdentifiers: new Set(),
@@ -1236,9 +1319,9 @@ async function readExistingLeeAppraiserIdentifiers(skipExistingNeon) {
     `
       select request_identifier, parcel_identifier
       from properties
-      where source_system = 'lee_appraiser'
+      where source_system = $1
     `,
-    [],
+    [sourceSystem],
   );
   /** @type {Set<string>} */
   const requestIdentifiers = new Set();
@@ -1598,7 +1681,8 @@ function validateMessage(value) {
     }
     return /** @type {LeePropertyFirstPermitParcelMessage} */ (message);
   }
-  if (message.type === "lee-property-first-seed-feeder") {
+  if (isPropertyFirstSeedFeederType(message.type)) {
+    const messageType = String(message.type);
     for (const fieldName of [
       "sourceCsvS3Uri",
       "workflowQueueUrl",
@@ -1613,8 +1697,15 @@ function validateMessage(value) {
         typeof message[fieldName] !== "string" ||
         !message[fieldName].trim()
       ) {
-        throw new Error(`lee-property-first-seed-feeder requires ${fieldName}`);
+        throw new Error(`${messageType} requires ${fieldName}`);
       }
+    }
+    if (
+      message.sourceSystem !== undefined &&
+      (typeof message.sourceSystem !== "string" ||
+        !message.sourceSystem.trim())
+    ) {
+      throw new Error(`${messageType} sourceSystem must be a non-empty string`);
     }
     for (const fieldName of ["batchSize", "maxPages", "requeueDelaySeconds"]) {
       const value = message[fieldName];
@@ -1623,7 +1714,7 @@ function validateMessage(value) {
         (typeof value !== "number" || !Number.isFinite(value) || value <= 0)
       ) {
         throw new Error(
-          `lee-property-first-seed-feeder ${fieldName} must be a positive number`,
+          `${messageType} ${fieldName} must be a positive number`,
         );
       }
     }
@@ -1634,29 +1725,25 @@ function validateMessage(value) {
         message.sendDelayMs < 0)
     ) {
       throw new Error(
-        "lee-property-first-seed-feeder sendDelayMs must be a non-negative number",
+        `${messageType} sendDelayMs must be a non-negative number`,
       );
     }
     if (message.backpressureQueues !== undefined) {
       if (!Array.isArray(message.backpressureQueues)) {
-        throw new Error(
-          "lee-property-first-seed-feeder backpressureQueues must be an array",
-        );
+        throw new Error(`${messageType} backpressureQueues must be an array`);
       }
       for (const item of message.backpressureQueues) {
         if (!isRecord(item)) {
           throw new Error(
-            "lee-property-first-seed-feeder backpressure queue entries must be objects",
+            `${messageType} backpressure queue entries must be objects`,
           );
         }
         if (typeof item.name !== "string" || !item.name.trim()) {
-          throw new Error(
-            "lee-property-first-seed-feeder backpressure queue requires name",
-          );
+          throw new Error(`${messageType} backpressure queue requires name`);
         }
         if (typeof item.queueUrl !== "string" || !item.queueUrl.trim()) {
           throw new Error(
-            "lee-property-first-seed-feeder backpressure queue requires queueUrl",
+            `${messageType} backpressure queue requires queueUrl`,
           );
         }
         if (
@@ -1665,7 +1752,7 @@ function validateMessage(value) {
           item.maxMessages <= 0
         ) {
           throw new Error(
-            "lee-property-first-seed-feeder backpressure queue requires positive maxMessages",
+            `${messageType} backpressure queue requires positive maxMessages`,
           );
         }
       }
@@ -1779,8 +1866,10 @@ async function processLeePropertyFirstSeedFeeder(message) {
     return;
   }
 
+  const sourceSystem = resolveFeederSourceSystem(message);
   const existing = await readExistingLeeAppraiserIdentifiers(
     message.skipExistingNeon !== false,
+    sourceSystem,
   );
   const batch = await enqueueLeePropertyFirstSeedBatch({
     message,
@@ -3013,7 +3102,7 @@ export const handler = async (event) => {
       await processLeePermitDetailBatch(message);
     } else if (message.type === "lee-property-first-permit-parcel") {
       await processLeePropertyFirstPermitParcel(message);
-    } else if (message.type === "lee-property-first-seed-feeder") {
+    } else if (isPropertyFirstSeedFeederMessage(message)) {
       await processLeePropertyFirstSeedFeeder(message);
     } else if (message.type === "sunbiz-corporate-address-match") {
       await processSunbizCorporateAddressMatch(message);

--- a/workflow/lambdas/transform-worker/index.mjs
+++ b/workflow/lambdas/transform-worker/index.mjs
@@ -1,8 +1,17 @@
+import { createRequire } from "module";
 import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
 import AdmZip from "adm-zip";
 import { transform } from "@elephant-xyz/cli/lib";
+
+// Patch Node's built-in fs with graceful-fs so that any EMFILE errors from
+// the CLI transform library (which may open 400+ files simultaneously on heavy
+// parcels) are automatically queued and retried rather than thrown immediately.
+// This must run before the transform() call at module init time.
+const require = createRequire(import.meta.url);
+const gracefulFs = require("graceful-fs");
+gracefulFs.gracefulify(require("fs"));
 import {
   executeWithTaskToken,
   parseS3Uri,
@@ -42,6 +51,7 @@ const DEFAULT_PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES = [
   "ShoppingCenterRegional",
   "Supermarket",
 ];
+const ALL_PROPERTY_FIRST_PERMIT_USAGE_TYPES_SENTINEL = "__ALL__";
 
 /**
  * @typedef {object} TransformInput
@@ -142,6 +152,20 @@ function resolvePropertyFirstPermitEligibleUsageTypes() {
 }
 
 /**
+ * Return true when the configured permit coverage scope should include every appraiser usage type.
+ *
+ * @param {string[]} eligibleUsageTypes - Parsed eligible usage type configuration.
+ * @returns {boolean} True when full property-first permit coverage is enabled.
+ */
+function isFullPropertyFirstPermitCoverageEnabled(eligibleUsageTypes) {
+  return eligibleUsageTypes.some(
+    (usageType) =>
+      usageType.trim().toUpperCase() ===
+      ALL_PROPERTY_FIRST_PERMIT_USAGE_TYPES_SENTINEL,
+  );
+}
+
+/**
  * Extract the Lee Appraiser property usage type from a transformed output zip.
  *
  * @param {string} outputZipLocal - Local transformed output zip path.
@@ -197,7 +221,8 @@ async function buildAndUploadPropertyFirstPermitEligibility({
   const { propertyUsageType, readError } =
     readPropertyUsageTypeFromTransformedZip(outputZipLocal);
   const shouldEnqueue =
-    propertyUsageType !== null && eligibleUsageTypeSet.has(propertyUsageType);
+    isFullPropertyFirstPermitCoverageEnabled(eligibleUsageTypes) ||
+    (propertyUsageType !== null && eligibleUsageTypeSet.has(propertyUsageType));
   const reason = shouldEnqueue
     ? "eligible_property_usage_type"
     : readError !== null

--- a/workflow/lambdas/transform-worker/package.json
+++ b/workflow/lambdas/transform-worker/package.json
@@ -13,7 +13,8 @@
     "@aws-sdk/client-s3": "^3.879.0",
     "@aws-sdk/client-sfn": "^3.879.0",
     "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#44fd046cfdc205a223cc7a62df5bfcaf003a395b",
-    "adm-zip": "^0.5.17"
+    "adm-zip": "^0.5.17",
+    "graceful-fs": "^4.2.11"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",


### PR DESCRIPTION
Generalizes the Lee-only property-first **seed-feeder** (the self-requeuing, backpressure full-run trigger) so it can drive any county — needed to run the full Palm Beach 654k ingestion. Lee behavior is preserved byte-for-byte.

## What
- `workflow/lambdas/permit-harvest-worker/index.mjs`:
  - Routes any `<county>-property-first-seed-feeder` type (regex), not just `lee-…`.
  - Optional `sourceSystem` field drives the `skipExistingNeon` dedup (default `lee_appraiser` → Lee unchanged; PB = `palm_beach_appraiser`).
  - State schema `…-state.v2` (generic); **still reads legacy `…lee-…-state.v1`** so an in-flight Lee run resumes.
  - Per-row workflow generation, backpressure, checkpoint mechanics unchanged.
- `scripts/send-palm-beach-seed-feeder.mjs` — sends ONE PB feeder message (dry-run verified).

## Validated
- Pilot of 25 PB parcels through the real pipeline (prepare→transform→archive→bulk-load) succeeded: 24 loaded, correct PB usage types, geometry present.
- `typecheck` clean; feeder dry-run prints the correct PB message.

## Deploy note
Requires a **`elephant-permit-harvest` worker redeploy** to ship (no CI for it). ⚠️ The deployed worker zip is from 2026-06-07 while the source has drifted — confirm intended scope before deploying to the Lee-shared prod Lambda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)