### PR TITLE
feat(scripts): self-healing seed-feeder watchdog + require fixed --job-id

### DIFF
--- a/scripts/send-palm-beach-seed-feeder.mjs
+++ b/scripts/send-palm-beach-seed-feeder.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  GetQueueUrlCommand,
+  SendMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+
+/**
+ * Palm Beach property-first seed-feeder sender.
+ *
+ * Builds and sends ONE Palm Beach feeder message to the permit-harvest queue.
+ * The feeder is the self-requeuing full-run trigger: it drips the whole Palm
+ * Beach seed CSV through the appraisal -> permit pipeline with backpressure,
+ * checkpointing progress in S3 and rescheduling itself with an SQS delay until
+ * the county is exhausted.
+ *
+ * Queue URLs and the environment bucket are resolved from the same
+ * CloudFormation stacks the enqueue scripts use. Per-parcel workflow routing is
+ * derived by the prepare state machine from the seed CSV's `county` column
+ * (-> `elephant-oracle-node-prepare-queue-palm-beach`), not from this message.
+ */
+const COUNTY = {
+  /** Feeder message discriminator routed by the permit-harvest worker. */
+  feederType: "palm-beach-property-first-seed-feeder",
+  /** Neon properties.source_system used by the worker's skipExistingNeon dedup. */
+  sourceSystem: "palm_beach_appraiser",
+  /** Slug used for generated S3 prefixes so the loader prefix is predictable. */
+  slug: "palm-beach-property-first-seed",
+  /** Per-county prepare queue name resolved for backpressure. */
+  prepareQueueName: "elephant-oracle-node-prepare-queue-palm-beach",
+};
+
+const DEFAULT_STACK_NAME = "elephant-oracle-node";
+const DEFAULT_PERMIT_STACK_NAME = "elephant-permit-harvest";
+const DEFAULT_SOURCE_CSV_S3_URI = "s3://counties-seeds/palm_beach.csv";
+/**
+ * Suggested (NOT default) jobId following the run-naming convention. Returned only in
+ * usage/error text so the operator can copy it. Deliberately NOT applied automatically:
+ * a date-derived jobId silently splits a multi-day run — a re-send after 00:00 UTC (manual
+ * or by the watchdog) would build a new date and start a BRAND-NEW job from row 0 instead
+ * of resuming the frozen one. A fixed `--job-id` is therefore REQUIRED (see parseArgs).
+ *
+ * @returns {string} A convention-following jobId for today's date.
+ */
+function suggestedJobId() {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  return `palm-beach-property-first-seed-all-${date}`;
+}
+
+// Seed CSV is ~282 MiB / 654k rows and the worker re-streams it from row 1 each
+// wakeup to skip to the checkpoint. Use a LARGE batch so that expensive scan is
+// amortized over many enqueues per wakeup (not re-paid per 200 rows). 2000 rows
+// of seed-upload + workflow-enqueue fits comfortably inside the 900s/4GB worker.
+const DEFAULT_BATCH_SIZE = 2000;
+const DEFAULT_REQUEUE_DELAY_SECONDS = 45;
+const DEFAULT_WORKFLOW_MAX_MESSAGES = 2000;
+const DEFAULT_PREPARE_MAX_MESSAGES = 5000;
+
+const cloudFormation = new CloudFormationClient({});
+const sqs = new SQSClient({});
+
+/**
+ * @typedef {object} CliOptions
+ * @property {string} stackName - Oracle-node CloudFormation stack name.
+ * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
+ * @property {string} sourceCsvS3Uri - Palm Beach seed CSV S3 URI.
+ * @property {string} jobId - REQUIRED fixed run identifier used for S3 partitioning; must
+ *   stay constant across every (re-)send so the run resumes instead of splitting.
+ * @property {boolean} dryRun - Print the feeder message without sending it.
+ */
+
+/**
+ * Print CLI usage instructions.
+ *
+ * @returns {void} Writes usage text to stdout.
+ */
+function showUsage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+    node scripts/send-palm-beach-seed-feeder.mjs --job-id <id> [--dry-run]
+
+Options:
+  --stack <name>          Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
+  --permit-stack <name>   Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
+  --source-csv-s3-uri <s3uri>
+                          Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --job-id <id>           REQUIRED. Stable run id, FIXED for the whole run. Do not rely on a
+                          date default: a re-send after 00:00 UTC would start a new job from
+                          row 0 and silently split the run. Suggested: ${suggestedJobId()}
+  --dry-run               Print the feeder message JSON without sending to SQS.
+  --help                  Show this help.
+
+Sends ONE feeder message to the permit-harvest queue. The worker then self-
+requeues, dripping the whole Palm Beach seed through the pipeline with workflow
+and prepare backpressure until the county is exhausted.
+`);
+}
+
+/**
+ * Return a trimmed string when a value is a non-empty string.
+ *
+ * @param {string | undefined} value - Candidate CLI value.
+ * @returns {string | undefined} Trimmed string when usable.
+ */
+function readOptionalString(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse command-line arguments into typed options.
+ *
+ * @param {string[]} argv - Raw argv excluding node and script path.
+ * @returns {CliOptions} Parsed CLI options.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      showUsage();
+      process.exit(0);
+    }
+    if (token === "--dry-run") {
+      values.dryRun = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[key] = next;
+    index += 1;
+  }
+
+  const jobId = readOptionalString(values["job-id"]);
+  if (!jobId) {
+    throw new Error(
+      "--job-id is REQUIRED and must be FIXED for the whole run. Do not rely on a date " +
+        "default: a re-send after 00:00 UTC (manual or by the watchdog) would start a " +
+        "BRAND-NEW job from row 0 and silently split the run. " +
+        `Suggested: --job-id ${suggestedJobId()}`,
+    );
+  }
+
+  return {
+    stackName: readOptionalString(values.stack) ?? DEFAULT_STACK_NAME,
+    permitStackName:
+      readOptionalString(values["permit-stack"]) ?? DEFAULT_PERMIT_STACK_NAME,
+    sourceCsvS3Uri:
+      readOptionalString(values["source-csv-s3-uri"]) ??
+      DEFAULT_SOURCE_CSV_S3_URI,
+    jobId,
+    dryRun: values.dryRun === true,
+  };
+}
+
+/**
+ * Read a CloudFormation output value from a deployed stack.
+ *
+ * @param {string} stackName - CloudFormation stack name.
+ * @param {string} outputKey - Output key to find.
+ * @returns {Promise<string>} Output value.
+ */
+async function getStackOutput(stackName, outputKey) {
+  const response = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (item) => item.OutputKey === outputKey,
+  );
+  if (!output?.OutputValue) {
+    throw new Error(`Stack ${stackName} does not expose ${outputKey}`);
+  }
+  return output.OutputValue;
+}
+
+/**
+ * Resolve an SQS queue URL from its name.
+ *
+ * @param {string} queueName - SQS queue name.
+ * @returns {Promise<string>} Queue URL.
+ */
+async function getQueueUrl(queueName) {
+  const response = await sqs.send(
+    new GetQueueUrlCommand({ QueueName: queueName }),
+  );
+  if (!response.QueueUrl) {
+    throw new Error(`Could not resolve queue URL for ${queueName}`);
+  }
+  return response.QueueUrl;
+}
+
+/**
+ * Build the Palm Beach property-first seed-feeder message from resolved infra.
+ *
+ * @param {object} params - Message build parameters.
+ * @param {CliOptions} params.cli - Parsed CLI options.
+ * @param {string} params.environmentBucketName - Output/seed/state S3 bucket name.
+ * @param {string} params.workflowQueueUrl - Appraisal workflow starter queue URL.
+ * @param {string} params.propertyFirstPermitQueueUrl - Property-first permit queue URL.
+ * @param {string} params.feederQueueUrl - Permit-harvest queue the feeder reschedules onto.
+ * @param {string} params.prepareQueueUrl - Palm Beach prepare queue URL for backpressure.
+ * @returns {Record<string, unknown>} Feeder message body.
+ */
+function buildFeederMessage({
+  cli,
+  environmentBucketName,
+  workflowQueueUrl,
+  propertyFirstPermitQueueUrl,
+  feederQueueUrl,
+  prepareQueueUrl,
+}) {
+  return {
+    type: COUNTY.feederType,
+    version: 1,
+    sourceSystem: COUNTY.sourceSystem,
+    jobId: cli.jobId,
+    sourceCsvS3Uri: cli.sourceCsvS3Uri,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    generatedSeedPrefix: `s3://${environmentBucketName}/seed-inputs/${COUNTY.slug}/${cli.jobId}`,
+    workflowOutputBaseUri: `s3://${environmentBucketName}/outputs/${COUNTY.slug}/${cli.jobId}`,
+    propertyFirstPermitOutputPrefix: `s3://${environmentBucketName}/permit-harvest/${COUNTY.slug}`,
+    stateS3Uri: `s3://${environmentBucketName}/permit-harvest/${cli.jobId}/feeder-state.json`,
+    batchSize: DEFAULT_BATCH_SIZE,
+    requeueDelaySeconds: DEFAULT_REQUEUE_DELAY_SECONDS,
+    // NOTE: prepare-queue backpressure intentionally omitted — the permit-harvest
+    // worker role lacks sqs:GetQueueAttributes on the per-county PB prepare queue
+    // (would crash the feeder with AccessDenied). Workflow-queue backpressure
+    // (the starter that feeds prepare) still governs overall flow. Re-add the
+    // prepare entry once the role is granted GetQueueAttributes on the PB queue.
+    backpressureQueues: [
+      {
+        name: "workflow",
+        queueUrl: workflowQueueUrl,
+        maxMessages: DEFAULT_WORKFLOW_MAX_MESSAGES,
+      },
+    ],
+  };
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {Promise<void>} Resolves after the feeder message is printed or sent.
+ */
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const [
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    prepareQueueUrl,
+  ] = await Promise.all([
+    getStackOutput(cli.stackName, "EnvironmentBucketName"),
+    getStackOutput(cli.stackName, "WorkflowQueueUrl"),
+    getStackOutput(cli.permitStackName, "PropertyFirstPermitQueueUrl"),
+    getStackOutput(cli.permitStackName, "PermitHarvestQueueUrl"),
+    getQueueUrl(COUNTY.prepareQueueName),
+  ]);
+
+  const feederMessage = buildFeederMessage({
+    cli,
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    prepareQueueUrl,
+  });
+
+  if (cli.dryRun) {
+    console.log(
+      JSON.stringify(
+        { dryRun: true, feederQueueUrl, feederMessage },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const response = await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: feederQueueUrl,
+      MessageBody: JSON.stringify(feederMessage),
+    }),
+  );
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: "palm_beach_property_first_seed_feeder_sent",
+      jobId: cli.jobId,
+      feederQueueUrl,
+      messageId: response.MessageId,
+    }),
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ level: "error", message }));
+  process.exit(1);
+});

--- a/scripts/watchdog-seed-feeder.sh
+++ b/scripts/watchdog-seed-feeder.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Self-healing watchdog for the property-first seed-feeder.
+#
+# The seed-feeder occasionally stops self-requeuing mid-run (its checkpoint
+# stops advancing while its ESM stays Enabled). The skills' documented recovery
+# is "re-send the same feeder message" (idempotent — it resumes from the S3
+# checkpoint). This automates that: poll the feeder-state checkpoint, and if it
+# has gone stale (and the county is not yet exhausted), re-send via the county
+# sender. Run detached (nohup + caffeinate) so it survives overnight.
+#
+# County-generic via env vars:
+#   STATE_S3_URI   s3://.../permit-harvest/<jobId>/feeder-state.json
+#   SENDER_CMD     command that re-sends ONE feeder message (resumes from checkpoint)
+#   STALE_SECONDS  re-send if checkpoint older than this (default 360)
+#   POLL_SECONDS   poll interval (default 120)
+#   AWS_PROFILE / AWS_REGION
+set -uo pipefail
+: "${STATE_S3_URI:?set STATE_S3_URI}"
+: "${SENDER_CMD:?set SENDER_CMD}"
+STALE_SECONDS="${STALE_SECONDS:-360}"
+POLL_SECONDS="${POLL_SECONDS:-120}"
+# Cooldown after a re-send: do NOT re-send again until this elapses, even if still
+# stale. Prevents piling up duplicate feeders (a pile runs concurrently and
+# deadlocks the worker). A single re-send normally revives within a minute.
+RESEND_COOLDOWN="${RESEND_COOLDOWN:-900}"
+LAST_RESEND=0
+
+echo "$(date -u +%H:%M:%S) watchdog start | state=$STATE_S3_URI stale=${STALE_SECONDS}s poll=${POLL_SECONDS}s cooldown=${RESEND_COOLDOWN}s"
+while true; do
+  STATE="$(aws s3 cp "$STATE_S3_URI" - 2>/dev/null)"
+  if [ -z "$STATE" ]; then
+    echo "$(date -u +%H:%M:%S) WARN: could not read state; re-sending to be safe"; eval "$SENDER_CMD" >/dev/null 2>&1
+    sleep "$POLL_SECONDS"; continue
+  fi
+  read -r EXHAUSTED ENQUEUED AGE < <(echo "$STATE" | python3 -c "
+import sys,json,datetime as dt
+d=json.load(sys.stdin)
+u=d.get('updatedAt');
+age=999999
+if u:
+    try:
+        t=dt.datetime.fromisoformat(u.replace('Z','+00:00'))
+        age=int((dt.datetime.now(dt.timezone.utc)-t).total_seconds())
+    except: pass
+print(str(d.get('sourceExhausted')).lower(), d.get('enqueuedCount',0), age)
+")
+  if [ "$EXHAUSTED" = "true" ]; then
+    echo "$(date -u +%H:%M:%S) DONE: sourceExhausted=true enqueued=$ENQUEUED — watchdog exiting"; exit 0
+  fi
+  NOW=$(date +%s)
+  SINCE_RESEND=$(( NOW - LAST_RESEND ))
+  if [ "$AGE" -gt "$STALE_SECONDS" ]; then
+    if [ "$SINCE_RESEND" -ge "$RESEND_COOLDOWN" ]; then
+      echo "$(date -u +%H:%M:%S) STALL: checkpoint ${AGE}s old (enqueued=$ENQUEUED) — RE-SENDING feeder"
+      eval "$SENDER_CMD" 2>&1 | grep -o '"messageId":"[^"]*"' | head -1
+      LAST_RESEND=$NOW
+    else
+      echo "$(date -u +%H:%M:%S) STALL but in cooldown (${SINCE_RESEND}s/${RESEND_COOLDOWN}s since last re-send) — waiting"
+    fi
+  else
+    echo "$(date -u +%H:%M:%S) ok: enqueued=$ENQUEUED, checkpoint ${AGE}s old"
+  fi
+  sleep "$POLL_SECONDS"
+done


### PR DESCRIPTION
Encodes two hard-won Palm Beach full-ingestion learnings into code so overnight runs don't need a babysitter and can't silently split.

## What's here
- **`scripts/watchdog-seed-feeder.sh`** (new): the property-first seed-feeder occasionally stops self-requeuing ~30 min into a run (checkpoint freezes while its ESM stays Enabled). Documented recovery is to re-send the same feeder message (idempotent — resumes from the S3 checkpoint). This watchdog polls the checkpoint and re-sends via the county `SENDER_CMD` on stall, **with a cooldown** (default 15 min). Reason for the cooldown: a naive no-cooldown re-sender previously piled ~150 duplicate feeders that ran concurrently and **deadlocked the worker**; one re-send normally revives it. County-generic via env (`STATE_S3_URI`, `SENDER_CMD`, `STALE_SECONDS`, `POLL_SECONDS`, `RESEND_COOLDOWN`).
- **`scripts/send-palm-beach-seed-feeder.mjs`**: require an explicit fixed `--job-id` instead of silently defaulting to the current date. The date default **splits a multi-day run at midnight** — a re-send after 00:00 UTC (manual or by the watchdog) built a new date and started a BRAND-NEW job from row 0 into a separate S3 prefix while the real job sat frozen. The date convention is now only a *suggested* value shown in usage/error text.

## Verification
- `node --check` passes; `bash -n` passes on the watchdog.
- Running the sender without `--job-id` now fails fast with a clear guard message and non-zero exit; `--help` documents it as REQUIRED.

## Note on branch base
Branched off `origin/main` to keep clear of unrelated uncommitted working-tree changes. `send-palm-beach-seed-feeder.mjs` is also introduced by open PR #172 (county-generic seed feeder); if that merges first, this PR's copy of the sender may need a trivial rebase (the jobId guard is the only delta over #172's version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)