### PR TITLE
feat(orange): appraisal onboarding — discovery docs + driver scripts

### DIFF
--- a/docs/orange-county-findings.md
+++ b/docs/orange-county-findings.md
@@ -1,0 +1,164 @@
+# Orange County, FL — Source Discovery Findings
+
+Consolidated source-discovery findings for Orange County, produced by the
+`county-discovery` stage. Mirrors the Lee County reference
+([`lee-county-findings.md`](./lee-county-findings.md)); the machine-readable registry is
+[`orange-sources.yaml`](./orange-sources.yaml).
+
+**County:** Orange County, FL. **FIPS 12095.** Seed roll `s3://counties-seeds/orange.csv`
+= **490,529 parcels** (geometry rides in-seed: `parcel_polygon`, `longitude`, `latitude`,
+`building_polygon`). A transform already exists at
+`Counties-trasform-scripts/orange/scripts/` (`data_extractor.js` + owner/structure/layout/
+utility mapping) — **reuse it, do not rebuild** — but it currently references
+`lakecopropappr.com` (Lake County), so **per-field validation is owed at the validate
+stage**.
+
+Scope this run: **discovery only.** No live ingest/deploy, no PR, no push.
+
+> ## ⚠️ CRITICAL — two things that will silently break the whole scrape
+>
+> 1. **14 → 15-digit PID normalization.** OCPA's PID is **15 digits, digits-only**. The
+>    seed's `parcel_id` is **14 digits** (a leading zero was stripped by numeric
+>    formatting) and returns `[]` against the API. The scrape **must**
+>    zero-pad the seed id to 15, call `GetSearchInfoByParcel` to get the **canonical**
+>    `parcelId`, then fan out `PRC/*` with that canonical id. Skip this and **all 490,529
+>    parcels 404**.
+> 2. **`-1` value masking on uncertified tax years.** For the current *uncertified* tax
+>    year OCPA returns value fields as **`-1`** (`isCertified:false`). Use the **certified
+>    year** (`GetPRCGeneralInfo.prcTaxYear`, currently **2025**) for real dollar values.
+
+## 1. Appraiser portal (property)
+
+- **Source:** Orange County Property Appraiser (OCPA).
+- **Public SPA:** `https://ocpaweb.ocpafl.org/parcelsearch` (Angular / ArcGIS).
+- **REAL data API** (plain GET, JSON, no auth, no cookie, no anti-bot, not geo-blocked):
+  base `https://ocpa-mainsite-afd-standard.azurefd.net/api/`. This is the
+  Palm-Beach-style plain-HTTP path — **no Browser Flow required.**
+- **Resolve / enumerate:** `api/QuickSearch/GetSearchInfoByParcel?pid=<15-digit>`
+  (also `ByAddress` / `ByOwnerName` / `ByInstrumentNumber` / `ByBookPage`).
+- **Full record = fan-out of `api/PRC/*` by canonical PID:**
+  - `GetPRCGeneralInfo` — owner / address / mailing / `dorCode` + `dorDescription` /
+    `prcTaxYear`
+  - `GetPRCPropertyValues` — land / building / market / assessed / exemptions / SOH cap
+  - `GetPRCPropFeatBldg` (+`Subareas`) — beds / baths / floors / grossArea / livingArea /
+    extWall / dateBuilt / estNewCost / bldgValue
+  - `GetPRCPropFeatLand` (+`Area`) — zoning / landQty / unitPrice
+  - `GetPRCPropFeatLegal` — propertyDescription
+  - `GetPRCPropFeatXfob` — extra features
+  - `GetPRCSales` (+`Subs`) — saleDate / saleAmt / instrNum / book / page / seller /
+    buyer / deedDesc
+  - `GetPRCCertifiedTaxes` / `GetPRCNonAdValorem` / `GetPRCTotalTaxes`
+  - `GetPRCPortValue` / `IncomeModel` / `Stats`
+- **Freshness:** `api/Parcel/GetSystemRefreshDate` (returned **07/01/2026**).
+- **Images:** `https://ocpaimages.ocpafl.org/api/Image/GetPIDImage` and `/GetPIDSketch`.
+- **Decoys — do NOT use:** `ocpaweb.ocpafl.org/api` returns 406 (decoy);
+  `ocpaservices …/ParcelInfoPrinterFriendly.aspx` 404'd (do not rely on it).
+- **Access:** plain HTTP JSON, no login / CAPTCHA / Cloudflare. Not geo-blocked.
+- **Refresh:** on-demand per-parcel, seed-driven; Structured Archive to S3.
+
+## 2. Parcel identifier
+
+- **OCPA "PID"** = **15 digits, digits-only** (e.g. `272003843803710`). Format is
+  Section-Township-Range-Subdivision-Block-Lot.
+- **⚠️ Seed mismatch:** the seed's `parcel_id` is **14 digits** (leading zero stripped by
+  numeric formatting) and returns `[]` against the API. **Normalization required:**
+  zero-pad seed id to 15 → call `GetSearchInfoByParcel` → use the returned canonical
+  `parcelId` for all `PRC/*` fan-out.
+- **Verified examples:**
+  - seed `12027000000001` → pad `012027000000001` → canonical `272001000000001`
+    (ORANGE COUNTY BCC, OAK LN, `totalCount:1`)
+  - seed `12228145000820` → pad `012228145000820` → canonical `282201145000820`
+    (KIM YOUNG AI, 6818 THOUSAND OAKS RD)
+
+## 3. Permit portal(s)
+
+Permits are **municipal and fragmented** across ~13 systems / ~9 vendors. Per the Lee/PB
+pattern, permits are **on-demand, NOT bulk** — build adapters via `county-permit-adapter`,
+one adapter per vendor.
+
+| Jurisdiction | Portal / vendor | URL | Status |
+| --- | --- | --- | --- |
+| Orange County (unincorporated) | **OC FastTrack** (custom county ASP.NET) | `https://fasttrack.ocfl.net/OnlineServices/PermitsAllTypes.aspx` | plain 200; search by permit# / address / parcel. **Biggest volume — build first** |
+| City of Orlando | **RelayView** | `https://cityoforlandofl-permits.myrelayview.com/` | 403 bot-challenge (needs browser session, **not** geo). **2nd biggest — build first** |
+| Apopka | OpenGov | `apopkafl.portal.opengov.com` | discovered |
+| Winter Park | **Tyler EnerGov / Civic Access** | `selfservice.cityofwinterpark.org/energov_prod` | discovered |
+| Maitland | **Tyler EnerGov** | `maitlandfl-energovpub.tylerhost.net` | discovered |
+| Ocoee | SagesGov / Clear Village | `permits.ocoee.org` | discovered |
+| Winter Garden | BS&A Online | `bsaonline.com` (uid=3123) | discovered |
+| Windermere + Oakland | PDCS LLC | `pdcsllc.com` | discovered |
+| Belle Isle | UES / teamues | — | needs-review |
+| Bay Lake + Lake Buena Vista | **Accela ACA** (CFTOD) | `ca.rcid.org/CitizenAccess` | discovered (bot-challenge) |
+| Eatonville | no online portal | — | none |
+| Edgewood | rides Orange County | — | needs-review |
+
+- **Highest-leverage reusable adapter: Tyler EnerGov Civic Access** — 2 Orange munis and
+  the most common vendor statewide. Build this adapter to maximize downstream reuse.
+- Detail contents (contractors, inspections, fees) and session/bootstrap needs are captured
+  per-vendor at the `county-permit-adapter` stage.
+
+## 4. Bulk data sources
+
+- **Seed parcel roll:** `s3://counties-seeds/orange.csv` (**490,529** parcels).
+- **GIS parcels (geometry), ArcGIS:**
+  `https://ocgis4.ocfl.net/arcgis/rest/services/Public_Base/MapServer/32/query`
+  where `PARCEL='<15-digit pid>'` (field `PARCEL`, `returnGeometry=true`).
+- Geometry **also rides in the seed CSV** (`parcel_polygon` / `longitude` / `latitude` /
+  `building_polygon`) — the transform reads it, same as Palm Beach.
+
+## 5. Usage-type vocabulary
+
+- Standard **4-digit FL DOR use codes**, inline in every record (`dorCode` /
+  `dorDescription`, `bldgDorCode`, `landDorCode`).
+- **Enumerable via:** `api/PropertyUseSearch/GetDORDescriptionList?dorGroupID=<n>` and
+  `GetSearchInfoByPropertyType?useCode=<dorCode>`.
+- **Samples:** `0103` Single Fam Class III · `1802` Office Mid-Rise · `2300`
+  Financial/Bank · `2700` Auto Dealership · `8900` Municipal · `5001` Ag.
+- Commercial/industrial codes (drives **permit-harvest eligibility**) map per the Lee
+  mapping.
+
+## 6. Additional data sources
+
+- **Sunbiz** (Florida statewide corporate registrations) — reuse the Lee/PB toolchain
+  (`sunbiz-corporate-ingest`). The only new per-county input is the **Orange ZIP-prefix
+  list** (collect Orange County ZIPs).
+- **BBB** — national / complete set, shared harvester (`bbb-harvest`). No per-county work.
+- **Recorder / official records** — Orange County Comptroller (noted as available).
+
+## 7. Source feasibility
+
+- **Appraisal:** plain-HTTP JSON API, no browser, no anti-bot → **full bulk collection
+  feasible from AWS us-east-1** (like Palm Beach). Estimate ~490,529 parcels ×
+  (1 resolve + ~10 PRC calls). **TODO — benchmark:** measure p50/p95 latency and safe
+  concurrency at a pilot before committing to a full-download plan.
+- **Permits:** on-demand only (fragmented vendors); no bulk artifact. Adapter throughput
+  measured per vendor at the `county-permit-adapter` stage.
+- **Sunbiz / BBB:** bulk, already-solved toolchain.
+
+## 8. Risks
+
+- **`-1` value masking** on uncertified tax years → must read the **certified year**
+  (`prcTaxYear`) for real dollar values.
+- **Seed 14 → 15-digit PID normalization** → must **pad + resolve** or every parcel 404s.
+- **Orlando (RelayView) + `rcid.org` (Accela) permit portals** issue **bot challenges** →
+  need a browser/residential-proxy session. These are **bot challenges, not geo-blocks.**
+- **Non-US local egress** (Serbia) is **irrelevant for production** — scraping runs from
+  AWS us-east-1; the OCPA appraiser API is confirmed not geo-blocked.
+
+## Named gaps / owed work (feeds later stages)
+
+- **Transform per-field validation owed** — `Counties-trasform-scripts/orange/scripts/`
+  still references `lakecopropappr.com`; prove field-by-field extraction vs OCPA at the
+  `validate-county-transform` stage.
+- **Permit portals needing a browser session** — Orlando (RelayView) and Bay Lake / Lake
+  Buena Vista (Accela `rcid.org`); Belle Isle and Edgewood are `needs-review`.
+- **Appraisal throughput benchmark TODO** — p50/p95 + safe concurrency at pilot.
+- **Orange ZIP-prefix list** — the one new Sunbiz input to collect.
+
+## Downstream
+
+All sources land in S3 (Structured Archive) and reconcile into the Neon query DB
+(`@elephant-xyz/query-db`). Completeness is validated per source via
+`validate-county-transform`, `monitoring-county-ingestion`, and `query-db-loading-matching`.
+
+**Out of scope this milestone:** IPFS publishing, on-chain/blockchain-style indexing, MCP
+exposure, NEO rewiring, Elephant.xyz UI (separate story, Asana `1215644141347714`).

--- a/docs/orange-county-findings.md
+++ b/docs/orange-county-findings.md
@@ -23,7 +23,7 @@ Scope this run: **discovery only.** No live ingest/deploy, no PR, no push.
 >    zero-pad the seed id to 15, call `GetSearchInfoByParcel` to get the **canonical**
 >    `parcelId`, then fan out `PRC/*` with that canonical id. Skip this and **all 490,529
 >    parcels 404**.
-> 2. **`-1` value masking on uncertified tax years.** For the current *uncertified* tax
+> 2. **`-1` value masking on uncertified tax years.** For the current _uncertified_ tax
 >    year OCPA returns value fields as **`-1`** (`isCertified:false`). Use the **certified
 >    year** (`GetPRCGeneralInfo.prcTaxYear`, currently **2025**) for real dollar values.
 
@@ -76,20 +76,20 @@ Permits are **municipal and fragmented** across ~13 systems / ~9 vendors. Per th
 pattern, permits are **on-demand, NOT bulk** — build adapters via `county-permit-adapter`,
 one adapter per vendor.
 
-| Jurisdiction | Portal / vendor | URL | Status |
-| --- | --- | --- | --- |
-| Orange County (unincorporated) | **OC FastTrack** (custom county ASP.NET) | `https://fasttrack.ocfl.net/OnlineServices/PermitsAllTypes.aspx` | plain 200; search by permit# / address / parcel. **Biggest volume — build first** |
-| City of Orlando | **RelayView** | `https://cityoforlandofl-permits.myrelayview.com/` | 403 bot-challenge (needs browser session, **not** geo). **2nd biggest — build first** |
-| Apopka | OpenGov | `apopkafl.portal.opengov.com` | discovered |
-| Winter Park | **Tyler EnerGov / Civic Access** | `selfservice.cityofwinterpark.org/energov_prod` | discovered |
-| Maitland | **Tyler EnerGov** | `maitlandfl-energovpub.tylerhost.net` | discovered |
-| Ocoee | SagesGov / Clear Village | `permits.ocoee.org` | discovered |
-| Winter Garden | BS&A Online | `bsaonline.com` (uid=3123) | discovered |
-| Windermere + Oakland | PDCS LLC | `pdcsllc.com` | discovered |
-| Belle Isle | UES / teamues | — | needs-review |
-| Bay Lake + Lake Buena Vista | **Accela ACA** (CFTOD) | `ca.rcid.org/CitizenAccess` | discovered (bot-challenge) |
-| Eatonville | no online portal | — | none |
-| Edgewood | rides Orange County | — | needs-review |
+| Jurisdiction                   | Portal / vendor                          | URL                                                              | Status                                                                                |
+| ------------------------------ | ---------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Orange County (unincorporated) | **OC FastTrack** (custom county ASP.NET) | `https://fasttrack.ocfl.net/OnlineServices/PermitsAllTypes.aspx` | plain 200; search by permit# / address / parcel. **Biggest volume — build first**     |
+| City of Orlando                | **RelayView**                            | `https://cityoforlandofl-permits.myrelayview.com/`               | 403 bot-challenge (needs browser session, **not** geo). **2nd biggest — build first** |
+| Apopka                         | OpenGov                                  | `apopkafl.portal.opengov.com`                                    | discovered                                                                            |
+| Winter Park                    | **Tyler EnerGov / Civic Access**         | `selfservice.cityofwinterpark.org/energov_prod`                  | discovered                                                                            |
+| Maitland                       | **Tyler EnerGov**                        | `maitlandfl-energovpub.tylerhost.net`                            | discovered                                                                            |
+| Ocoee                          | SagesGov / Clear Village                 | `permits.ocoee.org`                                              | discovered                                                                            |
+| Winter Garden                  | BS&A Online                              | `bsaonline.com` (uid=3123)                                       | discovered                                                                            |
+| Windermere + Oakland           | PDCS LLC                                 | `pdcsllc.com`                                                    | discovered                                                                            |
+| Belle Isle                     | UES / teamues                            | —                                                                | needs-review                                                                          |
+| Bay Lake + Lake Buena Vista    | **Accela ACA** (CFTOD)                   | `ca.rcid.org/CitizenAccess`                                      | discovered (bot-challenge)                                                            |
+| Eatonville                     | no online portal                         | —                                                                | none                                                                                  |
+| Edgewood                       | rides Orange County                      | —                                                                | needs-review                                                                          |
 
 - **Highest-leverage reusable adapter: Tyler EnerGov Civic Access** — 2 Orange munis and
   the most common vendor statewide. Build this adapter to maximize downstream reuse.

--- a/docs/orange-sources.yaml
+++ b/docs/orange-sources.yaml
@@ -1,0 +1,237 @@
+# Orange County, FL — public data source registry
+#
+# Consolidated source metadata for the Oracle ingestion categories.
+# Identifies each public data source (property, permits, Sunbiz, BBB) and stores
+# its access metadata: base URLs, access pattern, identifier, and refresh method.
+# Infra identifiers (AWS account, bucket, SQS) are intentionally NOT recorded here —
+# this registry describes external sources only. No secrets / account ids / connection
+# strings appear in this file.
+#
+# Out of scope this milestone: IPFS publishing, on-chain/blockchain-style indexing,
+# MCP exposure, NEO rewiring (separate story: Asana 1215644141347714).
+
+county:
+  name: Orange County
+  state: FL
+  fips: "12095"
+  seed:
+    location: s3://counties-seeds/orange.csv
+    parcels: 490529
+    geometry_in_seed:
+      - parcel_polygon
+      - longitude
+      - latitude
+      - building_polygon
+  parcel_identifier:
+    name: PID
+    description: >-
+      Orange County Property Appraiser (OCPA) "PID": 15 digits, digits-only
+      (e.g. 272003843803710). Format is Section-Township-Range-Subdivision-Block-Lot.
+    seed_normalization: >-
+      CRITICAL: the seed's parcel_id is 14 digits (a leading zero was stripped by
+      numeric formatting) and returns [] against the API. Normalization required:
+      zero-pad the seed id to 15 digits, call
+      QuickSearch/GetSearchInfoByParcel?pid=<15-digit> to obtain the canonical
+      parcelId, THEN fan out PRC/* with that canonical id. Skip this and all 490,529
+      parcels 404. Verified: seed 12027000000001 -> pad 012027000000001 -> canonical
+      272001000000001; seed 12228145000820 -> pad 012228145000820 -> canonical
+      282201145000820.
+
+sources:
+  - key: property-appraisal
+    category: property
+    name: Orange County Property Appraiser (OCPA)
+    public_spa: https://ocpaweb.ocpafl.org/parcelsearch # Angular / ArcGIS SPA (human UI)
+    base_urls:
+      - https://ocpa-mainsite-afd-standard.azurefd.net/api/ # REAL data API (plain GET JSON)
+    endpoints:
+      resolve:
+        - QuickSearch/GetSearchInfoByParcel?pid=<15-digit> # + ByAddress/ByOwnerName/ByInstrumentNumber/ByBookPage
+      record_fanout: # PRC/* called with the canonical parcelId
+        - PRC/GetPRCGeneralInfo # owner/address/mailing/dorCode+dorDescription/prcTaxYear
+        - PRC/GetPRCPropertyValues # land/building/market/assessed/exemptions/sohCap
+        - PRC/GetPRCPropFeatBldg # (+Subareas) beds/baths/floors/grossArea/livingArea/extWall/dateBuilt/estNewCost/bldgValue
+        - PRC/GetPRCPropFeatLand # (+Area) zoning/landQty/unitPrice
+        - PRC/GetPRCPropFeatLegal # propertyDescription
+        - PRC/GetPRCPropFeatXfob # extra features
+        - PRC/GetPRCSales # (+Subs) saleDate/saleAmt/instrNum/book/page/seller/buyer/deedDesc
+        - PRC/GetPRCCertifiedTaxes
+        - PRC/GetPRCNonAdValorem
+        - PRC/GetPRCTotalTaxes
+        - PRC/GetPRCPortValue
+        - PRC/GetPRCIncomeModel
+        - PRC/GetPRCStats
+      freshness:
+        - Parcel/GetSystemRefreshDate # returned 07/01/2026
+      usage_codes:
+        - PropertyUseSearch/GetDORDescriptionList?dorGroupID=<n>
+        - QuickSearch/GetSearchInfoByPropertyType?useCode=<dorCode>
+      images:
+        - https://ocpaimages.ocpafl.org/api/Image/GetPIDImage
+        - https://ocpaimages.ocpafl.org/api/Image/GetPIDSketch
+    decoys: # do NOT use
+      - https://ocpaweb.ocpafl.org/api # returns 406 (decoy)
+      - ocpaservices .../ParcelInfoPrinterFriendly.aspx # 404'd, unreliable
+    access_pattern:
+      mode: plain-http-json-api # Palm-Beach-style; NO Browser Flow required
+      tooling: plain GET fan-out (resolve -> PRC/*); reuse Counties-trasform-scripts/orange transform
+      auth: public (no login / cookie / CAPTCHA)
+      anti_bot: none observed; not geo-blocked
+      caveat: >-
+        -1 value masking: for the current UNCERTIFIED tax year, value fields return -1
+        (isCertified:false). Use the certified year (GetPRCGeneralInfo.prcTaxYear,
+        currently 2025) for real dollar values.
+    refresh:
+      method: on-demand per-parcel fan-out (seed-driven); Structured Archive to S3
+      cadence: on-demand / re-run per refresh
+      source_freshness: 07/01/2026 (Parcel/GetSystemRefreshDate)
+    implemented_by:
+      transform: Counties-trasform-scripts/orange/scripts/ # data_extractor.js + owner/structure/layout/utility mapping
+      transform_caveat: >-
+        currently references lakecopropappr.com (Lake County) — per-field validation
+        owed at the validate stage (validate-county-transform).
+      skill: county-appraisal-onboarding
+
+  - key: permits
+    category: permits
+    name: Orange County municipal permit portals (fragmented, ~13 systems / ~9 vendors)
+    access_pattern:
+      mode: on-demand runtime retrieval (NOT bulk) # per Lee/PB pattern
+      tooling: one adapter per vendor via county-permit-adapter
+      note: >-
+        Highest-leverage reusable adapter is Tyler EnerGov Civic Access (2 Orange munis
+        and the most common vendor statewide). Build OC FastTrack + Orlando RelayView
+        first (biggest volume).
+    jurisdictions:
+      - jurisdiction: Orange County (unincorporated)
+        vendor: OC FastTrack (custom county ASP.NET)
+        url: https://fasttrack.ocfl.net/OnlineServices/PermitsAllTypes.aspx
+        search: permit# / address / parcel
+        anti_bot: none (plain 200)
+        status: discovered
+        priority: build-first # biggest volume
+      - jurisdiction: City of Orlando
+        vendor: RelayView
+        url: https://cityoforlandofl-permits.myrelayview.com/
+        anti_bot: 403 bot-challenge (needs browser session; NOT geo-block)
+        status: needs-browser-session
+        priority: build-first # 2nd biggest
+      - jurisdiction: Apopka
+        vendor: OpenGov
+        url: https://apopkafl.portal.opengov.com
+        status: discovered
+      - jurisdiction: Winter Park
+        vendor: Tyler EnerGov / Civic Access
+        url: https://selfservice.cityofwinterpark.org/energov_prod
+        status: discovered
+      - jurisdiction: Maitland
+        vendor: Tyler EnerGov
+        url: https://maitlandfl-energovpub.tylerhost.net
+        status: discovered
+      - jurisdiction: Ocoee
+        vendor: SagesGov / Clear Village
+        url: https://permits.ocoee.org
+        status: discovered
+      - jurisdiction: Winter Garden
+        vendor: BS&A Online
+        url: https://bsaonline.com # uid=3123
+        status: discovered
+      - jurisdiction: Windermere + Oakland
+        vendor: PDCS LLC
+        url: https://pdcsllc.com
+        status: discovered
+      - jurisdiction: Belle Isle
+        vendor: UES / teamues
+        status: needs-review
+      - jurisdiction: Bay Lake + Lake Buena Vista
+        vendor: Accela ACA (CFTOD)
+        url: https://ca.rcid.org/CitizenAccess
+        anti_bot: bot-challenge (needs browser session)
+        status: needs-browser-session
+      - jurisdiction: Eatonville
+        vendor: none
+        status: no-online-portal
+      - jurisdiction: Edgewood
+        vendor: rides Orange County
+        status: needs-review
+    refresh:
+      method: on-demand parcel/address lookup per vendor adapter
+      cadence: on-demand
+    implemented_by:
+      skill: county-permit-adapter
+      highest_leverage_adapter: Tyler EnerGov Civic Access
+
+  - key: sunbiz
+    category: business-registration
+    name: Florida Sunbiz corporate registrations (FL Dept. of State)
+    base_urls:
+      - https://dos.fl.gov/sunbiz/other-services/data-downloads/ # bulk downloads index
+      - https://search.sunbiz.org/Inquiry/corporationsearch/SearchResults # live search (secondary)
+    access_pattern:
+      mode: batch-bulk-download (primary) + live address search (secondary enrichment)
+      tooling: reuse Lee/PB toolchain; statewide dataset, shared
+      auth: Data Access Portal public account; credentials out-of-band, never committed
+      anti_bot: Cloudflare managed challenge on plain curl -> headless Chromium
+      per_county_input: >-
+        the only new per-county input is the Orange County ZIP-prefix list — collect
+        Orange ZIPs and match across principal / mailing / registered-agent / officer
+        addresses.
+    refresh:
+      method: quarterly bulk corporate download -> ZIP-prefix extract -> lexicon transform
+      cadence: quarterly
+    implemented_by:
+      skill: sunbiz-corporate-ingest
+      runbook: docs/sunbiz-bulk-download-runbook.md
+
+  - key: bbb
+    category: business-reputation
+    name: Better Business Bureau (BBB) contractor reputation
+    base_urls:
+      - https://www.bbb.org/us/category/data # category harvest entry point
+    access_pattern:
+      mode: browser-scrape # national/complete set, shared across counties
+      tooling: Puppeteer (headless Chromium)
+      auth: public
+      anti_bot: Cloudflare challenge -> challenge-retry loop in the harvester
+    refresh:
+      method: category harvest for contractor reputation/quality enrichment
+      cadence: on-demand / periodic
+    implemented_by:
+      skill: bbb-harvest
+
+bulk_geometry:
+  - key: gis-parcels
+    name: Orange County GIS parcels (geometry)
+    url: https://ocgis4.ocfl.net/arcgis/rest/services/Public_Base/MapServer/32/query
+    query: PARCEL='<15-digit pid>' # field PARCEL, returnGeometry=true
+    note: geometry also rides in the seed CSV; the transform reads it (like Palm Beach).
+
+additional_sources:
+  - key: recorder
+    name: Orange County Comptroller (recorder / official records — deeds, mortgages, liens)
+    status: available (noted; not in scope this milestone)
+
+feasibility:
+  property-appraisal: >-
+    plain-HTTP JSON API, no browser, no anti-bot -> full bulk collection feasible from
+    AWS us-east-1 (like Palm Beach). Estimate ~490,529 parcels x (1 resolve + ~10 PRC
+    calls). TODO: benchmark p50/p95 latency + safe concurrency at a pilot before
+    committing to a full-download plan.
+  permits: on-demand only (fragmented vendors); throughput measured per vendor adapter.
+  sunbiz: bulk, already-solved toolchain.
+  bbb: bulk, already-solved toolchain.
+
+risks:
+  - -1 value masking on uncertified tax years -> use the certified year (prcTaxYear).
+  - seed 14 -> 15-digit PID normalization -> must pad + resolve or every parcel 404s.
+  - Orlando (RelayView) + rcid.org (Accela) permit portals issue bot challenges ->
+    need browser/residential-proxy session (bot challenge, NOT geo-block).
+  - non-US local egress (Serbia) irrelevant for prod -> scraping runs from AWS us-east-1;
+    OCPA appraiser API confirmed not geo-blocked.
+
+notes:
+  - Discovery stage only; no live ingest/deploy, no PR, no push performed this run.
+  - All sources land in S3 (Structured Archive) and reconcile into the Neon query DB
+    (read via @elephant-xyz/query-db).
+  - Completeness is validated per source (validate-county-transform,
+    monitoring-county-ingestion, query-db-loading-matching).

--- a/scripts/enqueue-orange-appraisal-property-first-from-seed.mjs
+++ b/scripts/enqueue-orange-appraisal-property-first-from-seed.mjs
@@ -15,21 +15,21 @@ import { readFile } from "fs/promises";
 import { Pool } from "pg";
 
 /**
- * Palm Beach county configuration. This file is a parameterized clone of
+ * Orange county configuration. This file is a parameterized clone of
  * scripts/enqueue-lee-appraisal-property-first-from-seed.mjs; only the values
  * below differ from the Lee run.
  *
  * The prepare state machine derives the per-county prepare queue name from the
  * seed CSV's `county` column (lowercased, spaces -> '-', '.' removed), NOT from
- * this object. With a seed `county` value of "Palm Beach" the state machine
- * targets `elephant-oracle-node-prepare-queue-palm-beach`, which already exists.
+ * this object. With a seed `county` value of "Orange" the state machine
+ * targets `elephant-oracle-node-prepare-queue-orange`, which already exists.
  */
 const COUNTY = {
   /** Human-readable county name used in log lines. */
   name: "Orange",
   /** Snake-case county key used in log message identifiers. */
   key: "orange",
-  /** Neon properties.source_system value for the Palm Beach appraiser source. */
+  /** Neon properties.source_system value for the Orange appraiser source. */
   sourceSystem: "orange_appraiser",
   /** Postgres application_name used for the dedup connection. */
   applicationName: "orange-appraisal-seed-enqueue",
@@ -68,7 +68,7 @@ async function readOnlyRows(filePath) {
 
 /**
  * @typedef {object} CliOptions
- * @property {string} sourceCsvS3Uri - Source Palm Beach county seed CSV S3 URI.
+ * @property {string} sourceCsvS3Uri - Source Orange county seed CSV S3 URI.
  * @property {string} stackName - Oracle-node CloudFormation stack name.
  * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
  * @property {string | undefined} workflowQueueUrl - Explicit workflow starter queue URL.
@@ -83,7 +83,7 @@ async function readOnlyRows(filePath) {
  * @property {number} sendDelayMs - Optional delay between SQS sends.
  * @property {number} concurrency - Number of seed uploads/workflow SQS sends to run concurrently.
  * @property {string} envFile - Local env file used when skipping properties already in Neon.
- * @property {boolean} skipExistingNeon - Skip rows whose Palm Beach Appraiser property is already present in Neon.
+ * @property {boolean} skipExistingNeon - Skip rows whose Orange Appraiser property is already present in Neon.
  * @property {boolean} dryRun - Print candidate workflow messages without uploading seeds or sending SQS messages.
  * @property {string | undefined} onlyRowsFile - Optional path to a newline-delimited list of 1-based source data-row numbers; only those rows are enqueued. Preserves the original sourceRowNumber so re-prepared outputs land in the existing row-* folders.
  */
@@ -110,8 +110,8 @@ async function readOnlyRows(filePath) {
 
 /**
  * @typedef {object} ExistingNeonIdentifiers
- * @property {Set<string>} requestIdentifiers - Existing Palm Beach Appraiser request/Folio identifiers.
- * @property {Set<string>} normalizedParcelIdentifiers - Existing normalized Palm Beach Appraiser parcel identifiers.
+ * @property {Set<string>} requestIdentifiers - Existing Orange Appraiser request/Folio identifiers.
+ * @property {Set<string>} normalizedParcelIdentifiers - Existing normalized Orange Appraiser parcel identifiers.
  */
 
 /**
@@ -145,7 +145,7 @@ Usage:
       --limit 0 --send-delay-ms 50
 
 Options:
-  --source-csv-s3-uri <s3uri>       Full Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --source-csv-s3-uri <s3uri>       Full Orange seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
   --stack <name>                    Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
   --permit-stack <name>             Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
   --workflow-queue-url <url>        WorkflowQueueUrl override.
@@ -400,20 +400,23 @@ async function loadEnvFile(envFile) {
 }
 
 /**
- * Normalize a Palm Beach parcel identifier (PCN) for duplicate checks and S3 key
+ * Normalize a Orange parcel identifier (PCN) for duplicate checks and S3 key
  * names.
  *
- * Palm Beach PCNs are 17-digit numeric strings that may arrive with separators
- * (dots/dashes) or leading/trailing whitespace. Only non-digit characters are
- * stripped, so distinct PCNs can never be collapsed together; separator and
- * whitespace differences normalize away while every digit is preserved.
+ * Orange parcel ids (PIDs) are 15-digit numeric strings that may arrive with
+ * separators (dashes) or leading/trailing whitespace, and the seed frequently
+ * carries a 14-digit value (a leading zero stripped by numeric CSV storage).
+ * Non-digit characters are stripped and the result is zero-padded to 15 so it
+ * matches the canonical 15-digit PID the workflow resolves and stores in Neon —
+ * otherwise the skipExistingNeon dedup never matches and every parcel is
+ * re-enqueued. Separator/whitespace differences normalize away; digits preserved.
  *
  * @param {unknown} value - Raw parcel identifier.
- * @returns {string | undefined} Digits-only parcel identifier.
+ * @returns {string | undefined} Canonical 15-digit parcel identifier.
  */
 function normalizeParcelIdentifier(value) {
   const normalized = String(value ?? "").replace(/[^0-9]/g, "");
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized.length > 0 ? normalized.padStart(15, "0") : undefined;
 }
 
 /**
@@ -465,7 +468,7 @@ function normalizeCsvHeader(header) {
 }
 
 /**
- * Read existing Palm Beach Appraiser identifiers from Neon so the S3 seed file
+ * Read existing Orange Appraiser identifiers from Neon so the S3 seed file
  * can be used to queue only new properties instead of replaying already-loaded
  * rows.
  *
@@ -523,7 +526,7 @@ async function readExistingNeonIdentifiers(cli) {
  * Return whether a source seed row is already present in Neon.
  *
  * @param {SeedRow} row - Parsed source seed row.
- * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers from Neon.
+ * @param {ExistingNeonIdentifiers} existing - Existing Orange Appraiser identifiers from Neon.
  * @returns {boolean} True when the row should be skipped as already loaded.
  */
 function isExistingNeonRow(row, existing) {
@@ -726,7 +729,7 @@ async function waitForAllPendingUploads(state) {
  * Stream the source seed CSV, generate one-property seeds, and enqueue workflow messages.
  *
  * @param {ResolvedOptions} options - Fully resolved options.
- * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers used for duplicate skips.
+ * @param {ExistingNeonIdentifiers} existing - Existing Orange Appraiser identifiers used for duplicate skips.
  * @param {Set<number> | undefined} onlyRows - When set, only these 1-based source data-row numbers are enqueued.
  * @returns {Promise<void>} Resolves when the requested rows have been processed.
  */

--- a/scripts/enqueue-orange-appraisal-property-first-from-seed.mjs
+++ b/scripts/enqueue-orange-appraisal-property-first-from-seed.mjs
@@ -1,0 +1,875 @@
+#!/usr/bin/env node
+
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+import { parse } from "csv-parse";
+import { readFile } from "fs/promises";
+import { Pool } from "pg";
+
+/**
+ * Palm Beach county configuration. This file is a parameterized clone of
+ * scripts/enqueue-lee-appraisal-property-first-from-seed.mjs; only the values
+ * below differ from the Lee run.
+ *
+ * The prepare state machine derives the per-county prepare queue name from the
+ * seed CSV's `county` column (lowercased, spaces -> '-', '.' removed), NOT from
+ * this object. With a seed `county` value of "Palm Beach" the state machine
+ * targets `elephant-oracle-node-prepare-queue-palm-beach`, which already exists.
+ */
+const COUNTY = {
+  /** Human-readable county name used in log lines. */
+  name: "Orange",
+  /** Snake-case county key used in log message identifiers. */
+  key: "orange",
+  /** Neon properties.source_system value for the Palm Beach appraiser source. */
+  sourceSystem: "orange_appraiser",
+  /** Postgres application_name used for the dedup connection. */
+  applicationName: "orange-appraisal-seed-enqueue",
+  /** S3 object metadata `source` tag written on each generated seed slice. */
+  seedSource: "counties-seeds-orange",
+  /** Slug used in generated S3 prefixes and the default job id. */
+  slug: "orange-property-first-seed",
+};
+
+/**
+ * Load a newline-delimited list of 1-based source data-row numbers into a Set.
+ * Blank lines and lines starting with '#' are ignored. Used to enqueue ONLY a
+ * specific subset of seed rows (e.g. parcels whose prepare failed) while keeping
+ * the original sourceRowNumber so outputs land in the existing row-* folders.
+ *
+ * @param {string} filePath - Path to the row-number list file.
+ * @returns {Promise<Set<number>>} Set of 1-based source data-row numbers.
+ */
+async function readOnlyRows(filePath) {
+  const content = await readFile(filePath, "utf8");
+  const rows = new Set();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const parsed = Number.parseInt(line, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--only-rows-file contains invalid row number: ${line}`);
+    }
+    rows.add(parsed);
+  }
+  if (rows.size === 0) {
+    throw new Error(`--only-rows-file ${filePath} contained no row numbers`);
+  }
+  return rows;
+}
+
+/**
+ * @typedef {object} CliOptions
+ * @property {string} sourceCsvS3Uri - Source Palm Beach county seed CSV S3 URI.
+ * @property {string} stackName - Oracle-node CloudFormation stack name.
+ * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
+ * @property {string | undefined} workflowQueueUrl - Explicit workflow starter queue URL.
+ * @property {string | undefined} propertyFirstPermitQueueUrl - Explicit property-first permit queue URL.
+ * @property {string | undefined} generatedSeedPrefix - S3 prefix for generated one-property CSV seed files.
+ * @property {string | undefined} workflowOutputBaseUri - S3 base URI for appraisal workflow outputs.
+ * @property {string | undefined} propertyFirstPermitOutputPrefix - S3 prefix consumed by the permit worker; the worker appends jobId.
+ * @property {string} jobId - Stable job identifier used for workflow messages and S3 partitioning.
+ * @property {number} limit - Maximum source rows to enqueue; 0 means all remaining source rows.
+ * @property {number} offset - Number of valid source rows to skip before enqueueing.
+ * @property {number} maxPages - Maximum Accela parcel-search pages per property.
+ * @property {number} sendDelayMs - Optional delay between SQS sends.
+ * @property {number} concurrency - Number of seed uploads/workflow SQS sends to run concurrently.
+ * @property {string} envFile - Local env file used when skipping properties already in Neon.
+ * @property {boolean} skipExistingNeon - Skip rows whose Palm Beach Appraiser property is already present in Neon.
+ * @property {boolean} dryRun - Print candidate workflow messages without uploading seeds or sending SQS messages.
+ * @property {string | undefined} onlyRowsFile - Optional path to a newline-delimited list of 1-based source data-row numbers; only those rows are enqueued. Preserves the original sourceRowNumber so re-prepared outputs land in the existing row-* folders.
+ */
+
+/**
+ * @typedef {object} ResolvedOptions
+ * @property {CliOptions} cli - Parsed CLI options.
+ * @property {string} workflowQueueUrl - Workflow starter queue URL.
+ * @property {string} propertyFirstPermitQueueUrl - Dedicated property-first permit queue URL.
+ * @property {string} generatedSeedPrefix - S3 prefix for generated one-property CSV seed files.
+ * @property {string} workflowOutputBaseUri - S3 base URI for appraisal workflow outputs.
+ * @property {string} propertyFirstPermitOutputPrefix - S3 prefix consumed by the permit worker.
+ */
+
+/**
+ * @typedef {object} S3UriParts
+ * @property {string} bucket - S3 bucket name.
+ * @property {string} key - S3 object key or prefix.
+ */
+
+/**
+ * @typedef {Record<string, string | undefined>} SeedRow
+ */
+
+/**
+ * @typedef {object} ExistingNeonIdentifiers
+ * @property {Set<string>} requestIdentifiers - Existing Palm Beach Appraiser request/Folio identifiers.
+ * @property {Set<string>} normalizedParcelIdentifiers - Existing normalized Palm Beach Appraiser parcel identifiers.
+ */
+
+/**
+ * @typedef {object} PendingUploadState
+ * @property {Set<Promise<void>>} pendingUploads - In-flight seed upload and workflow enqueue tasks.
+ * @property {Error | undefined} firstError - First asynchronous task failure seen by the scheduler.
+ */
+
+const DEFAULT_STACK_NAME = "elephant-oracle-node";
+const DEFAULT_PERMIT_STACK_NAME = "elephant-permit-harvest";
+const DEFAULT_SOURCE_CSV_S3_URI = "s3://counties-seeds/orange.csv";
+const DEFAULT_ENV_FILE = "../elephant-query-db/.env.local";
+const DEFAULT_JOB_ID = `${COUNTY.slug}-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+
+const cloudFormation = new CloudFormationClient({});
+const s3 = new S3Client({});
+const sqs = new SQSClient({});
+
+/**
+ * Print CLI usage instructions.
+ *
+ * @returns {void} Writes usage text to stdout.
+ */
+function showUsage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+    node scripts/enqueue-orange-appraisal-property-first-from-seed.mjs \
+      --source-csv-s3-uri s3://counties-seeds/orange.csv \
+      --job-id ${COUNTY.slug}-YYYYMMDD \
+      --limit 0 --send-delay-ms 50
+
+Options:
+  --source-csv-s3-uri <s3uri>       Full Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --stack <name>                    Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
+  --permit-stack <name>             Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
+  --workflow-queue-url <url>        WorkflowQueueUrl override.
+  --property-first-permit-queue-url <url>
+                                    PropertyFirstPermitQueueUrl override.
+  --generated-seed-prefix <s3uri>   Generated one-row CSV seed prefix. Default: environment bucket / seed-inputs / job id.
+  --workflow-output-base-uri <s3uri>
+                                    Appraisal workflow output base. Default: environment bucket / outputs / ${COUNTY.slug} / job id.
+  --property-first-permit-output-prefix <s3uri>
+                                    Permit artifact prefix. Default: environment bucket / permit-harvest / ${COUNTY.slug}.
+  --job-id <id>                     Stable run id. Default: ${DEFAULT_JOB_ID}
+  --limit <number>                  Source rows to enqueue after offset; 0 means all. Default: 1000
+  --offset <number>                 Valid source rows to skip. Default: 0
+  --max-pages <number>              Max Accela pages per parcel. Default: 200
+  --send-delay-ms <number>          Delay between SQS sends. Default: 0
+  --concurrency <number>            Concurrent S3 seed uploads/SQS sends. Default: 1
+  --env-file <path>                 Env file with DATABASE_URL. Default: ${DEFAULT_ENV_FILE}
+  --include-existing-neon           Do not skip properties already present in Neon.
+  --only-rows-file <path>           Newline-delimited 1-based source data-row numbers; enqueue ONLY those rows. Preserves the original sourceRowNumber so re-prepared outputs land in the existing row-* folders. Skip count for non-listed rows is reported as skippedNotInOnlyRows.
+  --dry-run                         Print messages without uploading generated seeds or sending SQS.
+  --help                            Show this help.
+
+This script uses the S3 seed CSV as the source of truth. It writes one seed CSV
+per property so the existing appraisal workflow can extract one full property,
+then the state machine enqueues the property-first permit worker to fetch all
+Accela permits and load appraisal+permits to Neon in one transaction.
+`);
+}
+
+/**
+ * Return a trimmed string when a value is a non-empty string.
+ *
+ * @param {unknown} value - Candidate value read from CLI args, CSV, or env.
+ * @returns {string | undefined} Trimmed string when usable.
+ */
+function readOptionalString(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse a non-negative integer CLI option.
+ *
+ * @param {string} optionName - CLI option name used in diagnostics.
+ * @param {string | undefined} rawValue - Raw CLI option value.
+ * @param {number} fallback - Default value when the option is absent.
+ * @returns {number} Parsed non-negative integer.
+ */
+function parseNonNegativeInteger(optionName, rawValue, fallback) {
+  if (rawValue === undefined) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `${optionName} must be a non-negative integer, received ${rawValue}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse a positive integer CLI option.
+ *
+ * @param {string} optionName - CLI option name used in diagnostics.
+ * @param {string | undefined} rawValue - Raw CLI option value.
+ * @param {number} fallback - Default value when the option is absent.
+ * @returns {number} Parsed positive integer.
+ */
+function parsePositiveInteger(optionName, rawValue, fallback) {
+  if (rawValue === undefined) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `${optionName} must be a positive integer, received ${rawValue}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse command-line arguments into typed options.
+ *
+ * @param {string[]} argv - Raw argv excluding node and script path.
+ * @returns {CliOptions} Parsed CLI options.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      showUsage();
+      process.exit(0);
+    }
+    if (token === "--dry-run") {
+      values.dryRun = true;
+      continue;
+    }
+    if (token === "--include-existing-neon") {
+      values.includeExistingNeon = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[key] = next;
+    index += 1;
+  }
+
+  return {
+    sourceCsvS3Uri:
+      readOptionalString(values["source-csv-s3-uri"]) ??
+      DEFAULT_SOURCE_CSV_S3_URI,
+    stackName: readOptionalString(values.stack) ?? DEFAULT_STACK_NAME,
+    permitStackName:
+      readOptionalString(values["permit-stack"]) ?? DEFAULT_PERMIT_STACK_NAME,
+    workflowQueueUrl: readOptionalString(values["workflow-queue-url"]),
+    propertyFirstPermitQueueUrl: readOptionalString(
+      values["property-first-permit-queue-url"],
+    ),
+    generatedSeedPrefix: readOptionalString(values["generated-seed-prefix"]),
+    workflowOutputBaseUri: readOptionalString(
+      values["workflow-output-base-uri"],
+    ),
+    propertyFirstPermitOutputPrefix: readOptionalString(
+      values["property-first-permit-output-prefix"],
+    ),
+    jobId: readOptionalString(values["job-id"]) ?? DEFAULT_JOB_ID,
+    limit: parseNonNegativeInteger(
+      "--limit",
+      readOptionalString(values.limit),
+      1000,
+    ),
+    offset: parseNonNegativeInteger(
+      "--offset",
+      readOptionalString(values.offset),
+      0,
+    ),
+    maxPages: parsePositiveInteger(
+      "--max-pages",
+      readOptionalString(values["max-pages"]),
+      200,
+    ),
+    sendDelayMs: parseNonNegativeInteger(
+      "--send-delay-ms",
+      readOptionalString(values["send-delay-ms"]),
+      0,
+    ),
+    concurrency: parsePositiveInteger(
+      "--concurrency",
+      readOptionalString(values.concurrency),
+      1,
+    ),
+    envFile: readOptionalString(values["env-file"]) ?? DEFAULT_ENV_FILE,
+    skipExistingNeon: values.includeExistingNeon !== true,
+    onlyRowsFile: readOptionalString(values["only-rows-file"]),
+    dryRun: values.dryRun === true,
+  };
+}
+
+/**
+ * Parse an S3 URI into bucket and key components.
+ *
+ * @param {string} uri - S3 URI in `s3://bucket/key` format.
+ * @returns {S3UriParts} Parsed S3 bucket and key.
+ */
+function parseS3Uri(uri) {
+  const match = /^s3:\/\/([^/]+)\/(.*)$/i.exec(uri);
+  if (!match) throw new Error(`Invalid S3 URI: ${uri}`);
+  return { bucket: match[1], key: match[2].replace(/\/$/, "") };
+}
+
+/**
+ * Read a CloudFormation output value from a deployed stack.
+ *
+ * @param {string} stackName - CloudFormation stack name.
+ * @param {string} outputKey - Output key to find.
+ * @returns {Promise<string>} Output value.
+ */
+async function getStackOutput(stackName, outputKey) {
+  const response = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (item) => item.OutputKey === outputKey,
+  );
+  if (!output?.OutputValue) {
+    throw new Error(`Stack ${stackName} does not expose ${outputKey}`);
+  }
+  return output.OutputValue;
+}
+
+/**
+ * Build all S3 prefixes and queue URLs after reading stack outputs.
+ *
+ * @param {CliOptions} cli - Parsed CLI options.
+ * @returns {Promise<ResolvedOptions>} Fully resolved options.
+ */
+async function resolveOptions(cli) {
+  const environmentBucketName = await getStackOutput(
+    cli.stackName,
+    "EnvironmentBucketName",
+  );
+  const workflowQueueUrl =
+    cli.workflowQueueUrl ??
+    (await getStackOutput(cli.stackName, "WorkflowQueueUrl"));
+  const propertyFirstPermitQueueUrl =
+    cli.propertyFirstPermitQueueUrl ??
+    (await getStackOutput(cli.permitStackName, "PropertyFirstPermitQueueUrl"));
+  return {
+    cli,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    generatedSeedPrefix:
+      cli.generatedSeedPrefix ??
+      `s3://${environmentBucketName}/seed-inputs/${COUNTY.slug}/${cli.jobId}`,
+    workflowOutputBaseUri:
+      cli.workflowOutputBaseUri ??
+      `s3://${environmentBucketName}/outputs/${COUNTY.slug}/${cli.jobId}`,
+    propertyFirstPermitOutputPrefix:
+      cli.propertyFirstPermitOutputPrefix ??
+      `s3://${environmentBucketName}/permit-harvest/${COUNTY.slug}`,
+  };
+}
+
+/**
+ * Load simple KEY=VALUE lines from an env file without adding a dotenv dependency.
+ *
+ * Existing process.env values win, which lets callers override DATABASE_URL from
+ * the shell or CI secret injection.
+ *
+ * @param {string} envFile - Path to an env file.
+ * @returns {Promise<void>} Resolves after environment variables are populated.
+ */
+async function loadEnvFile(envFile) {
+  const content = await readFile(envFile, "utf8");
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    const rawValue = line.slice(equalsIndex + 1).trim();
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.replace(/^['"]|['"]$/g, "");
+  }
+}
+
+/**
+ * Normalize a Palm Beach parcel identifier (PCN) for duplicate checks and S3 key
+ * names.
+ *
+ * Palm Beach PCNs are 17-digit numeric strings that may arrive with separators
+ * (dots/dashes) or leading/trailing whitespace. Only non-digit characters are
+ * stripped, so distinct PCNs can never be collapsed together; separator and
+ * whitespace differences normalize away while every digit is preserved.
+ *
+ * @param {unknown} value - Raw parcel identifier.
+ * @returns {string | undefined} Digits-only parcel identifier.
+ */
+function normalizeParcelIdentifier(value) {
+  const normalized = String(value ?? "").replace(/[^0-9]/g, "");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+/**
+ * Make a string safe and compact enough for a deterministic S3 object key part.
+ *
+ * @param {unknown} value - Source value.
+ * @param {string} fallback - Fallback when source value is blank.
+ * @returns {string} S3-safe key part.
+ */
+function safeKeyPart(value, fallback) {
+  const source = readOptionalString(value) ?? fallback;
+  const safe = source
+    .replace(/[^A-Za-z0-9._=-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return safe.length > 0 ? safe.slice(0, 96) : fallback;
+}
+
+/**
+ * Escape one CSV cell according to RFC4180-style quoting rules.
+ *
+ * @param {string | undefined} value - Raw cell value.
+ * @returns {string} CSV-encoded cell.
+ */
+function encodeCsvCell(value) {
+  const text = value ?? "";
+  if (!/[",\r\n]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a one-row CSV body preserving the source header order exactly.
+ *
+ * @param {string[]} columns - Source CSV column names in order.
+ * @param {SeedRow} row - Parsed source seed row.
+ * @returns {string} One-row CSV body with header.
+ */
+function buildOneRowCsv(columns, row) {
+  return `${columns.map(encodeCsvCell).join(",")}\n${columns.map((column) => encodeCsvCell(row[column])).join(",")}\n`;
+}
+
+/**
+ * Normalize a CSV parser header row into string column names.
+ *
+ * @param {unknown[]} header - Raw header values supplied by csv-parse.
+ * @returns {string[]} Header values converted to strings.
+ */
+function normalizeCsvHeader(header) {
+  return header.map((column) => String(column));
+}
+
+/**
+ * Read existing Palm Beach Appraiser identifiers from Neon so the S3 seed file
+ * can be used to queue only new properties instead of replaying already-loaded
+ * rows.
+ *
+ * @param {CliOptions} cli - Parsed CLI options containing env-file location.
+ * @returns {Promise<ExistingNeonIdentifiers>} Existing request and parcel identifiers.
+ */
+async function readExistingNeonIdentifiers(cli) {
+  if (!cli.skipExistingNeon) {
+    return {
+      requestIdentifiers: new Set(),
+      normalizedParcelIdentifiers: new Set(),
+    };
+  }
+  await loadEnvFile(cli.envFile);
+  const databaseUrl = readOptionalString(process.env.DATABASE_URL);
+  if (databaseUrl === undefined) {
+    throw new Error(
+      `DATABASE_URL is required to skip existing Neon properties; set it or pass --include-existing-neon`,
+    );
+  }
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    application_name: COUNTY.applicationName,
+    connectionTimeoutMillis: 15_000,
+    max: 1,
+    query_timeout: 180_000,
+    statement_timeout: 180_000,
+  });
+  try {
+    const result = await pool.query(
+      `
+        select request_identifier, parcel_identifier
+        from properties
+        where source_system = $1
+      `,
+      [COUNTY.sourceSystem],
+    );
+    const requestIdentifiers = new Set();
+    const normalizedParcelIdentifiers = new Set();
+    for (const row of result.rows) {
+      const requestIdentifier = readOptionalString(row.request_identifier);
+      if (requestIdentifier !== undefined)
+        requestIdentifiers.add(requestIdentifier);
+      const parcelIdentifier = normalizeParcelIdentifier(row.parcel_identifier);
+      if (parcelIdentifier !== undefined)
+        normalizedParcelIdentifiers.add(parcelIdentifier);
+    }
+    return { requestIdentifiers, normalizedParcelIdentifiers };
+  } finally {
+    await pool.end();
+  }
+}
+
+/**
+ * Return whether a source seed row is already present in Neon.
+ *
+ * @param {SeedRow} row - Parsed source seed row.
+ * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers from Neon.
+ * @returns {boolean} True when the row should be skipped as already loaded.
+ */
+function isExistingNeonRow(row, existing) {
+  const requestIdentifier = readOptionalString(row.source_identifier);
+  if (
+    requestIdentifier !== undefined &&
+    existing.requestIdentifiers.has(requestIdentifier)
+  ) {
+    return true;
+  }
+  const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+  return (
+    parcelIdentifier !== undefined &&
+    existing.normalizedParcelIdentifiers.has(parcelIdentifier)
+  );
+}
+
+/**
+ * Return whether a value behaves like a Node readable stream.
+ *
+ * @param {unknown} value - Candidate stream value from AWS SDK S3 response body.
+ * @returns {value is NodeJS.ReadableStream} True when `pipe` is available.
+ */
+function isNodeReadableStream(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "pipe" in value &&
+    typeof (/** @type {{ pipe?: unknown }} */ (value).pipe) === "function"
+  );
+}
+
+/**
+ * Upload one generated seed CSV and enqueue its workflow starter message.
+ *
+ * @param {object} params - Upload/enqueue parameters.
+ * @param {ResolvedOptions} params.options - Resolved queue URLs and prefixes.
+ * @param {string[]} params.columns - Source CSV columns in header order.
+ * @param {SeedRow} params.row - Source seed row.
+ * @param {number} params.sourceRowNumber - One-based source CSV data row number.
+ * @param {number} params.enqueuedIndex - Zero-based index among messages selected by this run.
+ * @returns {Promise<void>} Resolves after the seed is uploaded and the workflow message is sent.
+ */
+async function uploadSeedAndEnqueueWorkflow({
+  options,
+  columns,
+  row,
+  sourceRowNumber,
+  enqueuedIndex,
+}) {
+  const seedPrefix = parseS3Uri(options.generatedSeedPrefix);
+  const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+  if (parcelIdentifier === undefined) {
+    throw new Error(
+      `Source row ${String(sourceRowNumber)} is missing parcel_id`,
+    );
+  }
+  const requestIdentifier = safeKeyPart(row.source_identifier, "unknown-folio");
+  const seedKey = `${seedPrefix.key}/row-${String(sourceRowNumber).padStart(9, "0")}-folio-${requestIdentifier}-parcel-${safeKeyPart(parcelIdentifier, "unknown-parcel")}.csv`;
+  const workflowMessage = {
+    s3: {
+      bucket: { name: seedPrefix.bucket },
+      object: { key: seedKey },
+    },
+    output_base_uri: options.workflowOutputBaseUri,
+    propertyFirstPermitQueueUrl: options.propertyFirstPermitQueueUrl,
+    propertyFirstPermitJobId: options.cli.jobId,
+    propertyFirstPermitOutputPrefix: options.propertyFirstPermitOutputPrefix,
+    propertyFirstPermitMaxPages: options.cli.maxPages,
+    sourceSeedS3Uri: options.cli.sourceCsvS3Uri,
+    sourceSeedRowNumber: sourceRowNumber,
+  };
+
+  if (options.cli.dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          enqueuedIndex,
+          sourceRowNumber,
+          county: {
+            county_name: COUNTY.name,
+            county_key: COUNTY.key,
+            source: COUNTY.seedSource,
+            parcel_identifier: parcelIdentifier,
+            request_identifier: readOptionalString(row.source_identifier),
+          },
+          seedUri: `s3://${seedPrefix.bucket}/${seedKey}`,
+          workflowMessage,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: seedPrefix.bucket,
+      Key: seedKey,
+      Body: Buffer.from(buildOneRowCsv(columns, row), "utf8"),
+      ContentType: "text/csv; charset=utf-8",
+      Metadata: {
+        source: COUNTY.seedSource,
+        jobId: options.cli.jobId,
+        sourceRowNumber: String(sourceRowNumber),
+      },
+    }),
+  );
+  const response = await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: options.workflowQueueUrl,
+      MessageBody: JSON.stringify(workflowMessage),
+    }),
+  );
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_workflow_enqueued`,
+      enqueuedIndex,
+      sourceRowNumber,
+      messageId: response.MessageId,
+      parcelIdentifier,
+      requestIdentifier: readOptionalString(row.source_identifier),
+      seedUri: `s3://${seedPrefix.bucket}/${seedKey}`,
+    }),
+  );
+}
+
+/**
+ * Wait for a fixed amount of time.
+ *
+ * @param {number} milliseconds - Delay duration.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * Normalize an unknown thrown value into an Error instance.
+ *
+ * @param {unknown} error - Value thrown by an asynchronous upload/enqueue task.
+ * @returns {Error} Error instance suitable for later rethrowing.
+ */
+function toError(error) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Schedule a seed upload/workflow enqueue task and record its eventual failure
+ * without producing an unhandled rejection while other concurrent tasks finish.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @param {Promise<void>} uploadPromise - Upload/enqueue task promise to track.
+ * @returns {void}
+ */
+function schedulePendingUpload(state, uploadPromise) {
+  /** @type {Promise<void>} */
+  let trackedPromise;
+  trackedPromise = uploadPromise
+    .catch((error) => {
+      if (state.firstError === undefined) state.firstError = toError(error);
+    })
+    .finally(() => {
+      state.pendingUploads.delete(trackedPromise);
+    });
+  state.pendingUploads.add(trackedPromise);
+}
+
+/**
+ * Wait for at least one in-flight upload/enqueue task to complete and surface
+ * any failure captured by the concurrent scheduler.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @returns {Promise<void>} Resolves after one pending task completes successfully.
+ */
+async function waitForNextPendingUpload(state) {
+  if (state.pendingUploads.size === 0) return;
+  await Promise.race(state.pendingUploads);
+  if (state.firstError !== undefined) throw state.firstError;
+}
+
+/**
+ * Wait for all scheduled upload/enqueue tasks to settle and surface the first
+ * task failure if one occurred.
+ *
+ * @param {PendingUploadState} state - Mutable pending task scheduler state.
+ * @returns {Promise<void>} Resolves after all pending tasks settle successfully.
+ */
+async function waitForAllPendingUploads(state) {
+  while (state.pendingUploads.size > 0) {
+    await waitForNextPendingUpload(state);
+  }
+}
+
+/**
+ * Stream the source seed CSV, generate one-property seeds, and enqueue workflow messages.
+ *
+ * @param {ResolvedOptions} options - Fully resolved options.
+ * @param {ExistingNeonIdentifiers} existing - Existing Palm Beach Appraiser identifiers used for duplicate skips.
+ * @param {Set<number> | undefined} onlyRows - When set, only these 1-based source data-row numbers are enqueued.
+ * @returns {Promise<void>} Resolves when the requested rows have been processed.
+ */
+async function enqueueFromSeed(options, existing, onlyRows) {
+  const source = parseS3Uri(options.cli.sourceCsvS3Uri);
+  const response = await s3.send(
+    new GetObjectCommand({ Bucket: source.bucket, Key: source.key }),
+  );
+  if (!isNodeReadableStream(response.Body)) {
+    throw new Error(
+      `S3 object body is not a Node readable stream: ${options.cli.sourceCsvS3Uri}`,
+    );
+  }
+
+  /** @type {string[]} */
+  let columns = [];
+  const parser = response.Body.pipe(
+    parse({
+      columns: (header) => {
+        columns = normalizeCsvHeader(header);
+        return columns;
+      },
+      relax_column_count: true,
+      skip_empty_lines: true,
+      trim: false,
+    }),
+  );
+
+  let sourceRowNumber = 0;
+  let validRowNumber = 0;
+  let skippedExisting = 0;
+  let skippedInvalid = 0;
+  let skippedNotInOnlyRows = 0;
+  let enqueued = 0;
+  /** @type {PendingUploadState} */
+  const pendingUploadState = {
+    pendingUploads: new Set(),
+    firstError: undefined,
+  };
+
+  for await (const parsedRow of parser) {
+    if (pendingUploadState.firstError !== undefined)
+      throw pendingUploadState.firstError;
+    sourceRowNumber += 1;
+    if (onlyRows !== undefined && !onlyRows.has(sourceRowNumber)) {
+      skippedNotInOnlyRows += 1;
+      continue;
+    }
+    const row = /** @type {SeedRow} */ (parsedRow);
+    const parcelIdentifier = normalizeParcelIdentifier(row.parcel_id);
+    const requestIdentifier = readOptionalString(row.source_identifier);
+    if (parcelIdentifier === undefined || requestIdentifier === undefined) {
+      skippedInvalid += 1;
+      continue;
+    }
+    validRowNumber += 1;
+    if (validRowNumber <= options.cli.offset) continue;
+    if (isExistingNeonRow(row, existing)) {
+      skippedExisting += 1;
+      continue;
+    }
+    if (options.cli.limit > 0 && enqueued >= options.cli.limit) break;
+    schedulePendingUpload(
+      pendingUploadState,
+      uploadSeedAndEnqueueWorkflow({
+        options,
+        columns,
+        row,
+        sourceRowNumber,
+        enqueuedIndex: enqueued,
+      }),
+    );
+    enqueued += 1;
+    if (pendingUploadState.pendingUploads.size >= options.cli.concurrency) {
+      await waitForNextPendingUpload(pendingUploadState);
+    }
+    if (options.cli.sendDelayMs > 0) await sleep(options.cli.sendDelayMs);
+  }
+  await waitForAllPendingUploads(pendingUploadState);
+
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_seed_enqueue_complete`,
+      sourceCsvS3Uri: options.cli.sourceCsvS3Uri,
+      jobId: options.cli.jobId,
+      sourceRowsRead: sourceRowNumber,
+      validRowsSeen: validRowNumber,
+      skippedInvalid,
+      skippedExisting,
+      skippedNotInOnlyRows,
+      enqueued,
+      limit: options.cli.limit,
+      offset: options.cli.offset,
+      concurrency: options.cli.concurrency,
+      dryRun: options.cli.dryRun,
+      generatedSeedPrefix: options.generatedSeedPrefix,
+      workflowOutputBaseUri: options.workflowOutputBaseUri,
+      propertyFirstPermitOutputPrefix: options.propertyFirstPermitOutputPrefix,
+    }),
+  );
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {Promise<void>} Resolves when the enqueue run completes.
+ */
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const [options, existing, onlyRows] = await Promise.all([
+    resolveOptions(cli),
+    readExistingNeonIdentifiers(cli),
+    cli.onlyRowsFile !== undefined
+      ? readOnlyRows(cli.onlyRowsFile)
+      : Promise.resolve(undefined),
+  ]);
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: `${COUNTY.key}_appraisal_property_first_seed_enqueue_start`,
+      countyName: COUNTY.name,
+      countyKey: COUNTY.key,
+      sourceCsvS3Uri: cli.sourceCsvS3Uri,
+      jobId: cli.jobId,
+      workflowQueueUrl: options.workflowQueueUrl,
+      propertyFirstPermitQueueUrl: options.propertyFirstPermitQueueUrl,
+      skipExistingNeon: cli.skipExistingNeon,
+      existingRequestIdentifierCount: existing.requestIdentifiers.size,
+      existingParcelIdentifierCount: existing.normalizedParcelIdentifiers.size,
+      onlyRowsFile: cli.onlyRowsFile,
+      onlyRowsCount: onlyRows?.size,
+      limit: cli.limit,
+      offset: cli.offset,
+      concurrency: cli.concurrency,
+      dryRun: cli.dryRun,
+    }),
+  );
+  await enqueueFromSeed(options, existing, onlyRows);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ level: "error", message }));
+  process.exit(1);
+});

--- a/scripts/send-orange-seed-feeder.mjs
+++ b/scripts/send-orange-seed-feeder.mjs
@@ -7,18 +7,18 @@ import {
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 
 /**
- * Palm Beach property-first seed-feeder sender.
+ * Orange property-first seed-feeder sender.
  *
- * Builds and sends ONE Palm Beach feeder message to the permit-harvest queue.
- * The feeder is the self-requeuing full-run trigger: it drips the whole Palm
- * Beach seed CSV through the appraisal -> permit pipeline with backpressure,
+ * Builds and sends ONE Orange feeder message to the permit-harvest queue.
+ * The feeder is the self-requeuing full-run trigger: it drips the whole Orange
+ * seed CSV through the appraisal -> permit pipeline with backpressure,
  * checkpointing progress in S3 and rescheduling itself with an SQS delay until
  * the county is exhausted.
  *
  * Queue URLs and the environment bucket are resolved from the same
  * CloudFormation stacks the enqueue scripts use. Per-parcel workflow routing is
  * derived by the prepare state machine from the seed CSV's `county` column
- * (-> `elephant-oracle-node-prepare-queue-palm-beach`), not from this message.
+ * (-> `elephant-oracle-node-prepare-queue-orange`), not from this message.
  */
 const COUNTY = {
   /** Feeder message discriminator routed by the permit-harvest worker. */
@@ -67,7 +67,7 @@ const sqs = new SQSClient({});
  * @typedef {object} CliOptions
  * @property {string} stackName - Oracle-node CloudFormation stack name.
  * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
- * @property {string} sourceCsvS3Uri - Palm Beach seed CSV S3 URI.
+ * @property {string} sourceCsvS3Uri - Orange seed CSV S3 URI.
  * @property {string} jobId - REQUIRED fixed run identifier used for S3 partitioning; must
  *   stay constant across every (re-)send so the run resumes instead of splitting.
  * @property {boolean} dryRun - Print the feeder message without sending it.
@@ -88,7 +88,7 @@ Options:
   --stack <name>          Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
   --permit-stack <name>   Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
   --source-csv-s3-uri <s3uri>
-                          Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+                          Orange seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
   --job-id <id>           REQUIRED. Stable run id, FIXED for the whole run. Do not rely on a
                           date default: a re-send after 00:00 UTC would start a new job from
                           row 0 and silently split the run. Suggested: ${suggestedJobId()}
@@ -96,7 +96,7 @@ Options:
   --help                  Show this help.
 
 Sends ONE feeder message to the permit-harvest queue. The worker then self-
-requeues, dripping the whole Palm Beach seed through the pipeline with workflow
+requeues, dripping the whole Orange seed through the pipeline with workflow
 and prepare backpressure until the county is exhausted.
 `);
 }
@@ -187,7 +187,7 @@ async function getStackOutput(stackName, outputKey) {
 }
 
 /**
- * Build the Palm Beach property-first seed-feeder message from resolved infra.
+ * Build the Orange property-first seed-feeder message from resolved infra.
  *
  * @param {object} params - Message build parameters.
  * @param {CliOptions} params.cli - Parsed CLI options.

--- a/scripts/send-orange-seed-feeder.mjs
+++ b/scripts/send-orange-seed-feeder.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+
+/**
+ * Palm Beach property-first seed-feeder sender.
+ *
+ * Builds and sends ONE Palm Beach feeder message to the permit-harvest queue.
+ * The feeder is the self-requeuing full-run trigger: it drips the whole Palm
+ * Beach seed CSV through the appraisal -> permit pipeline with backpressure,
+ * checkpointing progress in S3 and rescheduling itself with an SQS delay until
+ * the county is exhausted.
+ *
+ * Queue URLs and the environment bucket are resolved from the same
+ * CloudFormation stacks the enqueue scripts use. Per-parcel workflow routing is
+ * derived by the prepare state machine from the seed CSV's `county` column
+ * (-> `elephant-oracle-node-prepare-queue-palm-beach`), not from this message.
+ */
+const COUNTY = {
+  /** Feeder message discriminator routed by the permit-harvest worker. */
+  feederType: "orange-property-first-seed-feeder",
+  /** Neon properties.source_system used by the worker's skipExistingNeon dedup. */
+  sourceSystem: "orange_appraiser",
+  /** Slug used for generated S3 prefixes so the loader prefix is predictable. */
+  slug: "orange-property-first-seed",
+  /**
+   * Per-county prepare queue name. Kept for documentation / future re-add of
+   * prepare-queue backpressure — see the omission note in buildFeederMessage.
+   */
+  prepareQueueName: "elephant-oracle-node-prepare-queue-orange",
+};
+
+const DEFAULT_STACK_NAME = "elephant-oracle-node";
+const DEFAULT_PERMIT_STACK_NAME = "elephant-permit-harvest";
+const DEFAULT_SOURCE_CSV_S3_URI = "s3://counties-seeds/orange.csv";
+/**
+ * Suggested (NOT default) jobId following the run-naming convention. Returned only in
+ * usage/error text so the operator can copy it. Deliberately NOT applied automatically:
+ * a date-derived jobId silently splits a multi-day run — a re-send after 00:00 UTC (manual
+ * or by the watchdog) would build a new date and start a BRAND-NEW job from row 0 instead
+ * of resuming the frozen one. A fixed `--job-id` is therefore REQUIRED (see parseArgs).
+ *
+ * @returns {string} A convention-following jobId for today's date.
+ */
+function suggestedJobId() {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  return `orange-property-first-seed-all-${date}`;
+}
+
+// Seed CSV is ~282 MiB / 654k rows and the worker re-streams it from row 1 each
+// wakeup to skip to the checkpoint. Use a LARGE batch so that expensive scan is
+// amortized over many enqueues per wakeup (not re-paid per 200 rows). 2000 rows
+// of seed-upload + workflow-enqueue fits comfortably inside the 900s/4GB worker.
+const DEFAULT_BATCH_SIZE = 2000;
+const DEFAULT_REQUEUE_DELAY_SECONDS = 45;
+const DEFAULT_WORKFLOW_MAX_MESSAGES = 2000;
+const DEFAULT_PREPARE_MAX_MESSAGES = 5000;
+
+const cloudFormation = new CloudFormationClient({});
+const sqs = new SQSClient({});
+
+/**
+ * @typedef {object} CliOptions
+ * @property {string} stackName - Oracle-node CloudFormation stack name.
+ * @property {string} permitStackName - Permit-harvest CloudFormation stack name.
+ * @property {string} sourceCsvS3Uri - Palm Beach seed CSV S3 URI.
+ * @property {string} jobId - REQUIRED fixed run identifier used for S3 partitioning; must
+ *   stay constant across every (re-)send so the run resumes instead of splitting.
+ * @property {boolean} dryRun - Print the feeder message without sending it.
+ */
+
+/**
+ * Print CLI usage instructions.
+ *
+ * @returns {void} Writes usage text to stdout.
+ */
+function showUsage() {
+  console.log(`
+Usage:
+  AWS_PROFILE=elephant-oracle-node AWS_REGION=us-east-1 \
+    node scripts/send-orange-seed-feeder.mjs --job-id <id> [--dry-run]
+
+Options:
+  --stack <name>          Oracle-node stack. Default: ${DEFAULT_STACK_NAME}
+  --permit-stack <name>   Permit-harvest stack. Default: ${DEFAULT_PERMIT_STACK_NAME}
+  --source-csv-s3-uri <s3uri>
+                          Palm Beach seed CSV. Default: ${DEFAULT_SOURCE_CSV_S3_URI}
+  --job-id <id>           REQUIRED. Stable run id, FIXED for the whole run. Do not rely on a
+                          date default: a re-send after 00:00 UTC would start a new job from
+                          row 0 and silently split the run. Suggested: ${suggestedJobId()}
+  --dry-run               Print the feeder message JSON without sending to SQS.
+  --help                  Show this help.
+
+Sends ONE feeder message to the permit-harvest queue. The worker then self-
+requeues, dripping the whole Palm Beach seed through the pipeline with workflow
+and prepare backpressure until the county is exhausted.
+`);
+}
+
+/**
+ * Return a trimmed string when a value is a non-empty string.
+ *
+ * @param {string | undefined} value - Candidate CLI value.
+ * @returns {string | undefined} Trimmed string when usable.
+ */
+function readOptionalString(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse command-line arguments into typed options.
+ *
+ * @param {string[]} argv - Raw argv excluding node and script path.
+ * @returns {CliOptions} Parsed CLI options.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      showUsage();
+      process.exit(0);
+    }
+    if (token === "--dry-run") {
+      values.dryRun = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    values[key] = next;
+    index += 1;
+  }
+
+  const jobId = readOptionalString(values["job-id"]);
+  if (!jobId) {
+    throw new Error(
+      "--job-id is REQUIRED and must be FIXED for the whole run. Do not rely on a date " +
+        "default: a re-send after 00:00 UTC (manual or by the watchdog) would start a " +
+        "BRAND-NEW job from row 0 and silently split the run. " +
+        `Suggested: --job-id ${suggestedJobId()}`,
+    );
+  }
+
+  return {
+    stackName: readOptionalString(values.stack) ?? DEFAULT_STACK_NAME,
+    permitStackName:
+      readOptionalString(values["permit-stack"]) ?? DEFAULT_PERMIT_STACK_NAME,
+    sourceCsvS3Uri:
+      readOptionalString(values["source-csv-s3-uri"]) ??
+      DEFAULT_SOURCE_CSV_S3_URI,
+    jobId,
+    dryRun: values.dryRun === true,
+  };
+}
+
+/**
+ * Read a CloudFormation output value from a deployed stack.
+ *
+ * @param {string} stackName - CloudFormation stack name.
+ * @param {string} outputKey - Output key to find.
+ * @returns {Promise<string>} Output value.
+ */
+async function getStackOutput(stackName, outputKey) {
+  const response = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (item) => item.OutputKey === outputKey,
+  );
+  if (!output?.OutputValue) {
+    throw new Error(`Stack ${stackName} does not expose ${outputKey}`);
+  }
+  return output.OutputValue;
+}
+
+/**
+ * Build the Palm Beach property-first seed-feeder message from resolved infra.
+ *
+ * @param {object} params - Message build parameters.
+ * @param {CliOptions} params.cli - Parsed CLI options.
+ * @param {string} params.environmentBucketName - Output/seed/state S3 bucket name.
+ * @param {string} params.workflowQueueUrl - Appraisal workflow starter queue URL.
+ * @param {string} params.propertyFirstPermitQueueUrl - Property-first permit queue URL.
+ * @param {string} params.feederQueueUrl - Permit-harvest queue the feeder reschedules onto.
+ * @returns {Record<string, unknown>} Feeder message body.
+ */
+function buildFeederMessage({
+  cli,
+  environmentBucketName,
+  workflowQueueUrl,
+  propertyFirstPermitQueueUrl,
+  feederQueueUrl,
+}) {
+  return {
+    type: COUNTY.feederType,
+    version: 1,
+    sourceSystem: COUNTY.sourceSystem,
+    jobId: cli.jobId,
+    sourceCsvS3Uri: cli.sourceCsvS3Uri,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+    generatedSeedPrefix: `s3://${environmentBucketName}/seed-inputs/${COUNTY.slug}/${cli.jobId}`,
+    workflowOutputBaseUri: `s3://${environmentBucketName}/outputs/${COUNTY.slug}/${cli.jobId}`,
+    propertyFirstPermitOutputPrefix: `s3://${environmentBucketName}/permit-harvest/${COUNTY.slug}`,
+    stateS3Uri: `s3://${environmentBucketName}/permit-harvest/${cli.jobId}/feeder-state.json`,
+    batchSize: DEFAULT_BATCH_SIZE,
+    requeueDelaySeconds: DEFAULT_REQUEUE_DELAY_SECONDS,
+    // NOTE: prepare-queue backpressure intentionally omitted — the permit-harvest
+    // worker role lacks sqs:GetQueueAttributes on the per-county PB prepare queue
+    // (would crash the feeder with AccessDenied). Workflow-queue backpressure
+    // (the starter that feeds prepare) still governs overall flow. Re-add the
+    // prepare entry once the role is granted GetQueueAttributes on the PB queue.
+    backpressureQueues: [
+      {
+        name: "workflow",
+        queueUrl: workflowQueueUrl,
+        maxMessages: DEFAULT_WORKFLOW_MAX_MESSAGES,
+      },
+    ],
+  };
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {Promise<void>} Resolves after the feeder message is printed or sent.
+ */
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const [
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+  ] = await Promise.all([
+    getStackOutput(cli.stackName, "EnvironmentBucketName"),
+    getStackOutput(cli.stackName, "WorkflowQueueUrl"),
+    getStackOutput(cli.permitStackName, "PropertyFirstPermitQueueUrl"),
+    getStackOutput(cli.permitStackName, "PermitHarvestQueueUrl"),
+    // NOTE: the PB prepare queue URL is intentionally NOT resolved here — prepare-
+    // queue backpressure is omitted because the permit-harvest worker role lacks
+    // sqs:GetQueueAttributes on the per-county PB prepare queue (see the omission
+    // note in buildFeederMessage). To re-add once the role is granted the
+    // permission, resolve it with getQueueUrl(COUNTY.prepareQueueName) and thread
+    // it into buildFeederMessage's backpressureQueues.
+  ]);
+
+  const feederMessage = buildFeederMessage({
+    cli,
+    environmentBucketName,
+    workflowQueueUrl,
+    propertyFirstPermitQueueUrl,
+    feederQueueUrl,
+  });
+
+  if (cli.dryRun) {
+    console.log(
+      JSON.stringify({ dryRun: true, feederQueueUrl, feederMessage }, null, 2),
+    );
+    return;
+  }
+
+  const response = await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: feederQueueUrl,
+      MessageBody: JSON.stringify(feederMessage),
+    }),
+  );
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: "orange_property_first_seed_feeder_sent",
+      jobId: cli.jobId,
+      feederQueueUrl,
+      messageId: response.MessageId,
+    }),
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ level: "error", message }));
+  process.exit(1);
+});


### PR DESCRIPTION
Onboarding artifacts for the Orange County appraisal ingest: `docs/orange-county-findings.md` (OCPA plain-HTTP API, permit-vendor catalog, seed = 490,529 parcels, the 14→15-digit PID + -1 value-masking gotchas) + `docs/orange-sources.yaml` (source registry), and the property-first driver scripts `scripts/enqueue-orange-appraisal-property-first-from-seed.mjs` + `scripts/send-orange-seed-feeder.mjs` (cloned/parameterized from Palm Beach). Pilot validated 25/25 scrape→transform→archive→load.