### PR TITLE
chore(downloader): bump @elephant-xyz/cli for Orange fetcher pad+retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11775,11 +11775,7 @@
         "zod": "^3.22.4"
       }
     },
-    "prepare": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "prepare": {},
     "prepare/lambdas/downloader": {
       "name": "downloader-lambda",
       "version": "1.0.0",
@@ -11788,7 +11784,7 @@
         "@aws-sdk/client-eventbridge": "^3.879.0",
         "@aws-sdk/client-s3": "^3.879.0",
         "@aws-sdk/client-sfn": "^3.879.0",
-        "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#44fd046cfdc205a223cc7a62df5bfcaf003a395b",
+        "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#8dd5f01f78d97bfed24065d69f31801613faca2f",
         "adm-zip": "^0.5.10",
         "csv-parse": "^5.6.0"
       },
@@ -11820,11 +11816,77 @@
         "@types/node": "^20.16.3"
       }
     },
-    "workflow": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+    "prepare/node_modules/@elephant-xyz/cli": {
+      "version": "1.58.1",
+      "resolved": "git+ssh://git@github.com/elephant-xyz/elephant-cli.git#8dd5f01f78d97bfed24065d69f31801613faca2f",
+      "integrity": "sha512-m2+d0TtSmtqr7Xb5J4w2LmNwNPzd7Mej9S8GPh2jZMBsGv3ITh06YFdoHrWCmQ37VBTKvrJmrV55dDzugyrTMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@elephant-xyz/fact-sheet": "^1.2.4",
+        "@ipld/dag-cbor": "^9.2.4",
+        "@ipld/dag-json": "^10.2.5",
+        "@ipld/dag-pb": "^4.1.5",
+        "@langchain/core": "^0.3.72",
+        "@langchain/langgraph": "^0.2.74",
+        "@langchain/openai": "^0.6.13",
+        "@sparticuz/chromium": "^138.0.2",
+        "@types/dot": "^1.1.7",
+        "acorn": "^8.15.0",
+        "adm-zip": "^0.5.16",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "async-mutex": "^0.5.0",
+        "blockstore-core": "^5.0.4",
+        "canonicalize": "^2.1.0",
+        "chalk": "^5.3.0",
+        "cheerio": "^1.1.2",
+        "cli-progress": "^3.12.0",
+        "commander": "^12.0.0",
+        "csv-parse": "^5.6.0",
+        "dot": "^1.1.3",
+        "dotenv": "^16.5.0",
+        "ethers": "^6.14.3",
+        "form-data": "^4.0.0",
+        "ipfs-unixfs": "^11.2.1",
+        "ipfs-unixfs-importer": "^15.4.0",
+        "langchain": "^0.3.31",
+        "multiformats": "^13.3.6",
+        "openai": "^5.12.2",
+        "ora": "^8.2.0",
+        "p-limit": "^6.2.0",
+        "prettier": "^3.2.5",
+        "puppeteer": "^24.17.0",
+        "puppeteer-core": "^24.17.0",
+        "winston": "^3.17.0",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "3.22.3"
+      },
+      "bin": {
+        "elephant-cli": "bin/elephant-cli"
+      }
     },
+    "prepare/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "prepare/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "workflow": {},
     "workflow-events/lambdas/dashboard-errors-widget": {
       "version": "1.0.0",
       "dependencies": {

--- a/prepare/lambdas/downloader/package.json
+++ b/prepare/lambdas/downloader/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/client-eventbridge": "^3.879.0",
     "@aws-sdk/client-s3": "^3.879.0",
     "@aws-sdk/client-sfn": "^3.879.0",
-    "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#44fd046cfdc205a223cc7a62df5bfcaf003a395b",
+    "@elephant-xyz/cli": "github:elephant-xyz/elephant-cli#8dd5f01f78d97bfed24065d69f31801613faca2f",
     "adm-zip": "^0.5.10",
     "csv-parse": "^5.6.0"
   },


### PR DESCRIPTION
Bumps the prepare/downloader's `@elephant-xyz/cli` pin to the merged #243 commit (`8dd5f01`) so the Orange native fetcher's **zero-pad-to-15 + retry-on-empty** is live. Required before the full Orange run — the raw `orange.csv` seed has 14-digit parcel ids that otherwise return `[]`. Only the downloader (runs `prepare()`) is bumped; `pre` stays on its pin (it runs the seed transform, not the fetcher). Root lockfile updated. Needs deploy after merge.