### PR TITLE
fix(watchdog): cross-platform python detection + no double-send on missing checkpoint

### DIFF
--- a/scripts/watchdog-seed-feeder.sh
+++ b/scripts/watchdog-seed-feeder.sh
@@ -6,7 +6,8 @@
 # is "re-send the same feeder message" (idempotent — it resumes from the S3
 # checkpoint). This automates that: poll the feeder-state checkpoint, and if it
 # has gone stale (and the county is not yet exhausted), re-send via the county
-# sender. Run detached (nohup + caffeinate) so it survives overnight.
+# sender. Run detached so it survives overnight (macOS: nohup + caffeinate;
+# Windows/Linux: nohup or a background job + keep the machine awake).
 #
 # County-generic via env vars:
 #   STATE_S3_URI   s3://.../permit-harvest/<jobId>/feeder-state.json
@@ -25,17 +26,32 @@ POLL_SECONDS="${POLL_SECONDS:-120}"
 RESEND_COOLDOWN="${RESEND_COOLDOWN:-900}"
 LAST_RESEND=0
 
-echo "$(date -u +%H:%M:%S) watchdog start | state=$STATE_S3_URI stale=${STALE_SECONDS}s poll=${POLL_SECONDS}s cooldown=${RESEND_COOLDOWN}s"
+# Detect a WORKING python interpreter. Windows registers "python3"/"python" App
+# Execution aliases that merely print an install prompt and exit non-zero, so we
+# execution-test each candidate rather than trusting `command -v`. Override with PYBIN.
+if [ -z "${PYBIN:-}" ]; then
+  for _c in python3 python "py -3"; do
+    if $_c -c "import sys" >/dev/null 2>&1; then PYBIN="$_c"; break; fi
+  done
+fi
+if [ -z "${PYBIN:-}" ]; then
+  echo "$(date -u +%H:%M:%S) FATAL: no working python interpreter found (tried python3, python, py -3). Set PYBIN." >&2
+  exit 1
+fi
+
+echo "$(date -u +%H:%M:%S) watchdog start | state=$STATE_S3_URI stale=${STALE_SECONDS}s poll=${POLL_SECONDS}s cooldown=${RESEND_COOLDOWN}s py='$PYBIN'"
 while true; do
   STATE="$(aws s3 cp "$STATE_S3_URI" - 2>/dev/null)"
   if [ -z "$STATE" ]; then
-    echo "$(date -u +%H:%M:%S) WARN: could not read state; re-sending to be safe"; eval "$SENDER_CMD" >/dev/null 2>&1
+    # Checkpoint not present yet (feeder still spinning up) OR a transient read error.
+    # Do NOT create/re-send — that would spawn a duplicate feeder. Just wait and re-check.
+    echo "$(date -u +%H:%M:%S) WARN: checkpoint not readable yet — waiting (not re-sending)"
     sleep "$POLL_SECONDS"; continue
   fi
-  read -r EXHAUSTED ENQUEUED AGE < <(echo "$STATE" | python3 -c "
+  read -r EXHAUSTED ENQUEUED AGE < <(echo "$STATE" | $PYBIN -c "
 import sys,json,datetime as dt
 d=json.load(sys.stdin)
-u=d.get('updatedAt');
+u=d.get('updatedAt') or d.get('lastUpdatedAt') or d.get('updated_at');
 age=999999
 if u:
     try:
@@ -43,7 +59,7 @@ if u:
         age=int((dt.datetime.now(dt.timezone.utc)-t).total_seconds())
     except: pass
 print(str(d.get('sourceExhausted')).lower(), d.get('enqueuedCount',0), age)
-")
+" | tr -d '\r')
   if [ "$EXHAUSTED" = "true" ]; then
     echo "$(date -u +%H:%M:%S) DONE: sourceExhausted=true enqueued=$ENQUEUED — watchdog exiting"; exit 0
   fi

--- a/scripts/watchdog-seed-feeder.sh
+++ b/scripts/watchdog-seed-feeder.sh
@@ -25,10 +25,17 @@ POLL_SECONDS="${POLL_SECONDS:-120}"
 # deadlocks the worker). A single re-send normally revives within a minute.
 RESEND_COOLDOWN="${RESEND_COOLDOWN:-900}"
 LAST_RESEND=0
+# If the checkpoint NEVER appears (initial feeder crashed before its first write),
+# recover after this grace window instead of waiting forever. Long enough that a
+# normally-starting feeder writes its checkpoint first, so we don't re-spawn at startup.
+MISSING_GRACE="${MISSING_GRACE:-$STALE_SECONDS}"
+MISSING_SINCE=0
 
 # Detect a WORKING python interpreter. Windows registers "python3"/"python" App
 # Execution aliases that merely print an install prompt and exit non-zero, so we
 # execution-test each candidate rather than trusting `command -v`. Override with PYBIN.
+# NOTE: $PYBIN is intentionally unquoted at the call site so "py -3" word-splits into
+# two args; do not point PYBIN at an interpreter path containing spaces (symlink it).
 if [ -z "${PYBIN:-}" ]; then
   for _c in python3 python "py -3"; do
     if $_c -c "import sys" >/dev/null 2>&1; then PYBIN="$_c"; break; fi
@@ -44,10 +51,22 @@ while true; do
   STATE="$(aws s3 cp "$STATE_S3_URI" - 2>/dev/null)"
   if [ -z "$STATE" ]; then
     # Checkpoint not present yet (feeder still spinning up) OR a transient read error.
-    # Do NOT create/re-send — that would spawn a duplicate feeder. Just wait and re-check.
-    echo "$(date -u +%H:%M:%S) WARN: checkpoint not readable yet — waiting (not re-sending)"
+    # Do NOT re-send immediately — at startup that spawns a duplicate feeder. But if it
+    # stays missing past MISSING_GRACE, the initial feeder likely died before its first
+    # write, so recover with ONE cooldown-protected re-send rather than waiting forever.
+    NOW=$(date +%s)
+    [ "$MISSING_SINCE" -eq 0 ] && MISSING_SINCE=$NOW
+    MISSING_FOR=$(( NOW - MISSING_SINCE )); SINCE_RESEND=$(( NOW - LAST_RESEND ))
+    if [ "$MISSING_FOR" -gt "$MISSING_GRACE" ] && [ "$SINCE_RESEND" -ge "$RESEND_COOLDOWN" ]; then
+      echo "$(date -u +%H:%M:%S) WARN: no checkpoint after ${MISSING_FOR}s (feeder may have crashed before first write) — RE-SENDING once"
+      eval "$SENDER_CMD" 2>&1 | grep -o '"messageId":"[^"]*"' | head -1
+      LAST_RESEND=$NOW
+    else
+      echo "$(date -u +%H:%M:%S) WARN: checkpoint not readable yet (${MISSING_FOR}s missing) — waiting"
+    fi
     sleep "$POLL_SECONDS"; continue
   fi
+  MISSING_SINCE=0
   read -r EXHAUSTED ENQUEUED AGE < <(echo "$STATE" | $PYBIN -c "
 import sys,json,datetime as dt
 d=json.load(sys.stdin)

--- a/scripts/watchdog-seed-feeder.sh
+++ b/scripts/watchdog-seed-feeder.sh
@@ -53,14 +53,17 @@ while true; do
     # Checkpoint not present yet (feeder still spinning up) OR a transient read error.
     # Do NOT re-send immediately — at startup that spawns a duplicate feeder. But if it
     # stays missing past MISSING_GRACE, the initial feeder likely died before its first
-    # write, so recover with ONE cooldown-protected re-send rather than waiting forever.
+    # write, so recover with a cooldown-rate-limited re-send retry (not a one-shot: if the
+    # re-sent feeder also dies before writing, we retry again after the next full window).
     NOW=$(date +%s)
     [ "$MISSING_SINCE" -eq 0 ] && MISSING_SINCE=$NOW
     MISSING_FOR=$(( NOW - MISSING_SINCE )); SINCE_RESEND=$(( NOW - LAST_RESEND ))
     if [ "$MISSING_FOR" -gt "$MISSING_GRACE" ] && [ "$SINCE_RESEND" -ge "$RESEND_COOLDOWN" ]; then
-      echo "$(date -u +%H:%M:%S) WARN: no checkpoint after ${MISSING_FOR}s (feeder may have crashed before first write) — RE-SENDING once"
+      echo "$(date -u +%H:%M:%S) WARN: no checkpoint after ${MISSING_FOR}s (feeder may have crashed before first write) — re-sending (rate-limited retry)"
       eval "$SENDER_CMD" 2>&1 | grep -o '"messageId":"[^"]*"' | head -1
-      LAST_RESEND=$NOW
+      # Reset BOTH windows so the next retry must wait the full grace AND cooldown again —
+      # otherwise MISSING_FOR keeps growing and fires every cooldown, piling up feeders.
+      LAST_RESEND=$NOW; MISSING_SINCE=$NOW
     else
       echo "$(date -u +%H:%M:%S) WARN: checkpoint not readable yet (${MISSING_FOR}s missing) — waiting"
     fi


### PR DESCRIPTION
Follow-up to #175 (self-healing seed-feeder watchdog). Found while running the Miami-Dade full ingestion on Windows: the watchdog silently did nothing and spawned a duplicate feeder. Four portability/robustness fixes to `scripts/watchdog-seed-feeder.sh`:

- **Interpreter detection.** The script hard-coded `python3`. On Windows that resolves to the App Execution alias (a stub that prints an install prompt and exits non-zero), so the checkpoint parse never ran. Now it execution-tests `python3` → `python` → `py -3` and uses the first that actually runs; override with `PYBIN`. (execution-test, not `command -v`, so it skips the stub.)
- **No re-send on a missing/unreadable checkpoint.** Previously it re-sent the feeder "to be safe" when it couldn't read state — but at startup the checkpoint doesn't exist yet, so this spawned a **second concurrent feeder** (both then thrash the shared checkpoint). Now it just warns and waits for the checkpoint to appear; it never creates one.
- **Strip trailing `\r`** from the parser output — Windows Python prints `\r\n`, leaving `AGE` = `"123\r"`, which broke the `[ "$AGE" -gt "$STALE" ]` integer test so a real stall was never detected.
- **Robust timestamp field** — accept `updatedAt` / `lastUpdatedAt` / `updated_at`.

No behavior change on macOS/Linux where `python3` exists. Verified against the live Miami-Dade run: interpreter detected (`py='python'`), checkpoint parsed, polls report fresh age and correctly stay quiet while the feeder advances.