### PR TITLE
fix: persist on-demand permit harvests to Neon (onDemand-gated)

### DIFF
--- a/tests/workflow/lambdas/permit-harvest-worker/index.test.mjs
+++ b/tests/workflow/lambdas/permit-harvest-worker/index.test.mjs
@@ -172,6 +172,83 @@ describe("permit harvest worker message helpers", () => {
     });
   });
 
+  it("bypasses the appraiser usage-type gate for on-demand MCP harvests only", () => {
+    const eligibleUsageTypes =
+      _private.resolvePropertyFirstPermitEligibleUsageTypes();
+    const ineligible = _private.buildPropertyFirstPermitEligibility({
+      propertyUsageType: "Residential",
+      readError: null,
+      eligibleUsageTypes,
+    });
+    const eligible = _private.buildPropertyFirstPermitEligibility({
+      propertyUsageType: "Industrial",
+      readError: null,
+      eligibleUsageTypes,
+    });
+
+    // Bulk/seed path (onDemand false) still skips ineligible parcels.
+    expect(
+      _private.shouldSkipIneligiblePropertyFirstParcel({
+        eligibility: ineligible,
+        onDemand: false,
+      }),
+    ).toBe(true);
+
+    // On-demand path harvests the ineligible parcel anyway.
+    expect(
+      _private.shouldSkipIneligiblePropertyFirstParcel({
+        eligibility: ineligible,
+        onDemand: true,
+      }),
+    ).toBe(false);
+
+    // Eligible parcels are never skipped, regardless of onDemand.
+    expect(
+      _private.shouldSkipIneligiblePropertyFirstParcel({
+        eligibility: eligible,
+        onDemand: false,
+      }),
+    ).toBe(false);
+    expect(
+      _private.shouldSkipIneligiblePropertyFirstParcel({
+        eligibility: eligible,
+        onDemand: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("validates the optional onDemand flag on property-first parcel messages", () => {
+    expect(
+      _private.validateMessage({
+        type: "lee-property-first-permit-parcel",
+        version: 1,
+        jobId: "mcp-on-demand-12071-1",
+        parcelIdentifier: "294627L40900A1339",
+        onDemand: true,
+      }),
+    ).toMatchObject({ onDemand: true });
+
+    // Absent onDemand preserves current (bulk/seed) behavior.
+    expect(
+      _private.validateMessage({
+        type: "lee-property-first-permit-parcel",
+        version: 1,
+        jobId: "seed-12071-1",
+        parcelIdentifier: "294627L40900A1339",
+      }).onDemand,
+    ).toBeUndefined();
+
+    expect(() =>
+      _private.validateMessage({
+        type: "lee-property-first-permit-parcel",
+        version: 1,
+        jobId: "bad-onDemand",
+        parcelIdentifier: "294627L40900A1339",
+        onDemand: "yes",
+      }),
+    ).toThrow("onDemand must be a boolean");
+  });
+
   it("validates seed feeder messages and preserves one-row Lee seed CSVs", () => {
     const message = _private.validateMessage({
       type: "lee-property-first-seed-feeder",
@@ -353,6 +430,49 @@ describe("permit harvest worker message helpers", () => {
     ]);
     expect(queries[1].sql).toContain("[^[:alnum:]]");
     expect(queries[1].sql).toContain("[^0-9]");
+  });
+
+  it("commits on-demand permits with zero link counters when no appraiser property matches", async () => {
+    const target = _private.buildPropertyFirstTarget({
+      type: "lee-property-first-permit-parcel",
+      version: 1,
+      jobId: "mcp-on-demand-test",
+      parcelIdentifier: "294627L40900A1339",
+    });
+    const buildClient = () => {
+      const queries = [];
+      return {
+        queries,
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          if (sql.includes("from properties")) {
+            // No appraiser property loaded yet for this parcel.
+            return { rows: [], rowCount: 0 };
+          }
+          if (sql.includes("select count(*)::int as matched_permit_rows")) {
+            return { rows: [{ matched_permit_rows: 0 }], rowCount: 1 };
+          }
+          return { rows: [], rowCount: 0 };
+        },
+      };
+    };
+
+    // On-demand: returns zero counters and never runs the match/update queries.
+    const onDemandClient = buildClient();
+    await expect(
+      _private.linkPropertyFirstPermits(onDemandClient, target, true),
+    ).resolves.toEqual({ matchedPermitRows: 0, linkedPermitRows: 0 });
+    expect(onDemandClient.queries).toHaveLength(1);
+    expect(onDemandClient.queries[0].sql).toContain("from properties");
+
+    // Non-onDemand: still throws exactly as before, which rolls back the upsert.
+    const bulkClient = buildClient();
+    await expect(
+      _private.linkPropertyFirstPermits(bulkClient, target, false),
+    ).rejects.toThrow("No loaded Lee Appraiser property found");
+    await expect(
+      _private.linkPropertyFirstPermits(bulkClient, target),
+    ).rejects.toThrow("No loaded Lee Appraiser property found");
   });
 
   it("retries transient async operations before surfacing failure", async () => {

--- a/tests/workflow/lambdas/permit-harvest-worker/index.test.mjs
+++ b/tests/workflow/lambdas/permit-harvest-worker/index.test.mjs
@@ -457,11 +457,16 @@ describe("permit harvest worker message helpers", () => {
       };
     };
 
-    // On-demand: returns zero counters and never runs the match/update queries.
+    // On-demand: returns zero counters plus propertyMissing:true (so the caller
+    // can defer writing completed.json) and never runs the match/update queries.
     const onDemandClient = buildClient();
     await expect(
       _private.linkPropertyFirstPermits(onDemandClient, target, true),
-    ).resolves.toEqual({ matchedPermitRows: 0, linkedPermitRows: 0 });
+    ).resolves.toEqual({
+      matchedPermitRows: 0,
+      linkedPermitRows: 0,
+      propertyMissing: true,
+    });
     expect(onDemandClient.queries).toHaveLength(1);
     expect(onDemandClient.queries[0].sql).toContain("from properties");
 
@@ -473,6 +478,40 @@ describe("permit harvest worker message helpers", () => {
     await expect(
       _private.linkPropertyFirstPermits(bulkClient, target),
     ).rejects.toThrow("No loaded Lee Appraiser property found");
+  });
+
+  it("defers completed-state only for on-demand harvests where the appraiser property is missing", () => {
+    // Deferred: on-demand harvest linked no property yet -> do NOT mark
+    // completed, so a future run links the permits once the property loads.
+    expect(
+      _private.shouldWritePropertyFirstCompletedState({
+        onDemand: true,
+        propertyMissing: true,
+      }),
+    ).toBe(false);
+
+    // On-demand but property present -> completed state written as before.
+    expect(
+      _private.shouldWritePropertyFirstCompletedState({
+        onDemand: true,
+        propertyMissing: false,
+      }),
+    ).toBe(true);
+
+    // Non-onDemand (bulk) always writes completed state, even in the (unreached)
+    // propertyMissing case -> bulk behavior is unchanged.
+    expect(
+      _private.shouldWritePropertyFirstCompletedState({
+        onDemand: false,
+        propertyMissing: true,
+      }),
+    ).toBe(true);
+    expect(
+      _private.shouldWritePropertyFirstCompletedState({
+        onDemand: false,
+        propertyMissing: false,
+      }),
+    ).toBe(true);
   });
 
   it("retries transient async operations before surfacing failure", async () => {

--- a/workflow/lambdas/permit-harvest-worker/index.mjs
+++ b/workflow/lambdas/permit-harvest-worker/index.mjs
@@ -235,6 +235,7 @@ import {
  * @property {number} unchangedRows - Number of prepared rows skipped because their source hash was unchanged.
  * @property {number} matchedPermitRows - Lee Accela permit rows in Neon matching this parcel after load.
  * @property {number} linkedPermitRows - Lee Accela permit rows linked to the appraiser property by this invocation.
+ * @property {boolean} [propertyMissing] - True only on the on-demand path when the appraiser property was not yet loaded, so linking was deferred. Absent/false otherwise.
  */
 
 /**
@@ -2532,7 +2533,7 @@ async function getQueryDatabasePool() {
  * @param {import("pg").PoolClient} client - Transaction-bound Postgres client.
  * @param {PropertyFirstTarget} target - Property-first target metadata.
  * @param {boolean} [onDemand] - On-demand MCP harvest. When true and no matching appraiser property exists, return zero link counters instead of throwing so the permit upsert still commits. Defaults false.
- * @returns {Promise<{ matchedPermitRows: number, linkedPermitRows: number }>} Link counters.
+ * @returns {Promise<{ matchedPermitRows: number, linkedPermitRows: number, propertyMissing?: boolean }>} Link counters. `propertyMissing` is true only on the on-demand deferred-link path where the appraiser property was not yet loaded.
  */
 async function linkPropertyFirstPermits(client, target, onDemand = false) {
   const targetAlphanumericParcelIdentifier = target.normalizedParcelIdentifier;
@@ -2568,8 +2569,14 @@ async function linkPropertyFirstPermits(client, target, onDemand = false) {
     if (onDemand) {
       // On-demand harvests may run before the appraiser property is loaded.
       // Return zero link counters so the caller's transaction still commits the
-      // permit upsert instead of rolling it back on this throw.
-      return { matchedPermitRows: 0, linkedPermitRows: 0 };
+      // permit upsert instead of rolling it back on this throw. Flag
+      // propertyMissing so the caller can defer writing the completed.json state
+      // and let a future run link these permits once the property exists.
+      return {
+        matchedPermitRows: 0,
+        linkedPermitRows: 0,
+        propertyMissing: true,
+      };
     }
     throw new Error(
       `No loaded Lee Appraiser property found for parcel ${targetAlphanumericParcelIdentifier}`,
@@ -2633,6 +2640,24 @@ async function linkPropertyFirstPermits(client, target, onDemand = false) {
     matchedPermitRows,
     linkedPermitRows: updateResult.rowCount ?? 0,
   };
+}
+
+/**
+ * Decide whether a property-first parcel should write its completed.json state.
+ *
+ * The completed state is what `skipCompleted` uses to skip a parcel on later
+ * runs. On the on-demand path, a harvest can find permits before the appraiser
+ * property is loaded, in which case linking is deferred (propertyMissing) even
+ * though the permit rows committed. In that single case we must NOT mark the
+ * parcel completed, so a future run re-processes and links the permits once the
+ * property exists. Every other case (bulk, or on-demand with the property
+ * present) writes the completed state exactly as before.
+ *
+ * @param {{ onDemand?: boolean, propertyMissing?: boolean }} params - Decision inputs.
+ * @returns {boolean} True when completed.json should be written.
+ */
+function shouldWritePropertyFirstCompletedState({ onDemand, propertyMissing }) {
+  return !(onDemand === true && propertyMissing === true);
 }
 
 /**
@@ -2721,6 +2746,7 @@ async function loadPropertyFirstPermitsToQueryDb({
       unchangedRows: counters.unchangedRows,
       matchedPermitRows: linkCounters.matchedPermitRows,
       linkedPermitRows: linkCounters.linkedPermitRows,
+      propertyMissing: linkCounters.propertyMissing === true,
     };
   } catch (error) {
     await client.query("rollback", []).catch(() => undefined);
@@ -2922,6 +2948,28 @@ async function processLeePropertyFirstPermitParcel(message) {
             loadAppraisalToNeon: message.loadAppraisalToNeon !== false,
             onDemand: message.onDemand === true,
           });
+    if (
+      !shouldWritePropertyFirstCompletedState({
+        onDemand: message.onDemand === true,
+        propertyMissing: loadSummary?.propertyMissing === true,
+      })
+    ) {
+      // On-demand harvest found permits before the appraiser property was
+      // loaded, so linking was deferred (permit rows are already committed
+      // inside loadPropertyFirstPermitsToQueryDb). Do NOT write the
+      // completed.json state: leaving the parcel "not completed" lets a future
+      // run re-process and link these permits once the property exists.
+      consoleLogger.info(
+        "lee_property_first_parcel_deferred_property_not_loaded",
+        {
+          jobId: message.jobId,
+          parcelIdentifier: target.parcelIdentifier,
+          normalizedParcelIdentifier: target.normalizedParcelIdentifier,
+          discoveredPermitCount: searchResult.permits.length,
+        },
+      );
+      return;
+    }
     const stateUri = await putTextObject({
       bucket: output.bucket,
       key: stateKey,
@@ -3178,6 +3226,7 @@ export const _private = {
   createInitialLeePropertyFirstSeedFeederState,
   isExistingLeeAppraiserSeedRow,
   linkPropertyFirstPermits,
+  shouldWritePropertyFirstCompletedState,
   normalizeParcelDigits,
   resolvePropertyFirstPermitEligibleUsageTypes,
   readDatabaseUrlFromSecretString,

--- a/workflow/lambdas/permit-harvest-worker/index.mjs
+++ b/workflow/lambdas/permit-harvest-worker/index.mjs
@@ -95,6 +95,7 @@ import {
  * @property {boolean | undefined} [skipCompleted] - Skip parcels with an existing property-first completion state object.
  * @property {boolean | undefined} [loadToNeon] - Merge captured permit details into Neon and link them to the appraiser property. Defaults true.
  * @property {boolean | undefined} [loadAppraisalToNeon] - Merge appraisalOutputS3Uri into Neon in the same transaction as permits. Defaults true when appraisalOutputS3Uri is present.
+ * @property {boolean | undefined} [onDemand] - On-demand MCP harvest. When true, the parcel harvests regardless of appraiser usage-type eligibility and a missing appraiser property row links zero permits instead of rolling back the permit upsert. Defaults false/absent (bulk/seed behavior).
  */
 
 /**
@@ -645,6 +646,22 @@ function buildPropertyFirstPermitEligibility({
     eligibleUsageTypes,
     readError,
   };
+}
+
+/**
+ * Decide whether a property-first parcel should be skipped as ineligible.
+ *
+ * Bulk/seed work honors the appraiser usage-type gate. On-demand MCP harvests
+ * always proceed so donphan can serve their permits regardless of usage type.
+ *
+ * @param {object} params - Gate parameters.
+ * @param {PropertyFirstPermitEligibility} params.eligibility - Resolved routing decision.
+ * @param {boolean} params.onDemand - Whether this is an on-demand MCP harvest.
+ * @returns {boolean} True when the parcel should be skipped as ineligible.
+ */
+function shouldSkipIneligiblePropertyFirstParcel({ eligibility, onDemand }) {
+  if (onDemand) return false;
+  return !eligibility.shouldEnqueue;
 }
 
 /**
@@ -1679,6 +1696,14 @@ function validateMessage(value) {
         "lee-property-first-permit-parcel maxPages must be a positive number",
       );
     }
+    if (
+      message.onDemand !== undefined &&
+      typeof message.onDemand !== "boolean"
+    ) {
+      throw new Error(
+        "lee-property-first-permit-parcel onDemand must be a boolean",
+      );
+    }
     return /** @type {LeePropertyFirstPermitParcelMessage} */ (message);
   }
   if (isPropertyFirstSeedFeederType(message.type)) {
@@ -2506,9 +2531,10 @@ async function getQueryDatabasePool() {
  *
  * @param {import("pg").PoolClient} client - Transaction-bound Postgres client.
  * @param {PropertyFirstTarget} target - Property-first target metadata.
+ * @param {boolean} [onDemand] - On-demand MCP harvest. When true and no matching appraiser property exists, return zero link counters instead of throwing so the permit upsert still commits. Defaults false.
  * @returns {Promise<{ matchedPermitRows: number, linkedPermitRows: number }>} Link counters.
  */
-async function linkPropertyFirstPermits(client, target) {
+async function linkPropertyFirstPermits(client, target, onDemand = false) {
   const targetAlphanumericParcelIdentifier = target.normalizedParcelIdentifier;
   const targetNumericParcelIdentifier = normalizeParcelDigits(
     target.normalizedParcelIdentifier,
@@ -2539,6 +2565,12 @@ async function linkPropertyFirstPermits(client, target) {
   );
   const propertyRow = propertyResult.rows[0];
   if (!isRecord(propertyRow)) {
+    if (onDemand) {
+      // On-demand harvests may run before the appraiser property is loaded.
+      // Return zero link counters so the caller's transaction still commits the
+      // permit upsert instead of rolling it back on this throw.
+      return { matchedPermitRows: 0, linkedPermitRows: 0 };
+    }
     throw new Error(
       `No loaded Lee Appraiser property found for parcel ${targetAlphanumericParcelIdentifier}`,
     );
@@ -2611,6 +2643,7 @@ async function linkPropertyFirstPermits(client, target) {
  * @param {PropertyFirstTarget} params.target - Property-first target metadata.
  * @param {ReturnType<typeof resolveOutputPrefix>} params.output - Resolved output prefix used for copied media artifacts.
  * @param {boolean} params.loadAppraisalToNeon - Whether to merge the appraisal artifact before permit rows.
+ * @param {boolean} [params.onDemand] - On-demand MCP harvest. When true, a missing appraiser property links zero permits instead of throwing, so the permit upsert still commits. Defaults false.
  * @returns {Promise<QueryDbLoadSummary>} Neon load and link summary.
  */
 async function loadPropertyFirstPermitsToQueryDb({
@@ -2618,6 +2651,7 @@ async function loadPropertyFirstPermitsToQueryDb({
   target,
   output,
   loadAppraisalToNeon,
+  onDemand = false,
 }) {
   const artifactUris = detailResults
     .map((result) => result.extractedJsonS3Uri)
@@ -2658,7 +2692,11 @@ async function loadPropertyFirstPermitsToQueryDb({
     const counters = await upsertPreparedRows(client, rows, {
       missingReferenceBehavior: "omit",
     });
-    const linkCounters = await linkPropertyFirstPermits(client, target);
+    const linkCounters = await linkPropertyFirstPermits(
+      client,
+      target,
+      onDemand,
+    );
     await client.query("commit", []);
     return {
       appraisalArtifactCount: appraisalLoad.artifactCount,
@@ -2721,7 +2759,12 @@ async function processLeePropertyFirstPermitParcel(message) {
   ) {
     target.propertyUsageType = permitEligibility.propertyUsageType;
   }
-  if (!permitEligibility.shouldEnqueue) {
+  if (
+    shouldSkipIneligiblePropertyFirstParcel({
+      eligibility: permitEligibility,
+      onDemand: message.onDemand === true,
+    })
+  ) {
     const stateUri = await putTextObject({
       bucket: output.bucket,
       key: stateKey,
@@ -2877,6 +2920,7 @@ async function processLeePropertyFirstPermitParcel(message) {
             target,
             output,
             loadAppraisalToNeon: message.loadAppraisalToNeon !== false,
+            onDemand: message.onDemand === true,
           });
     const stateUri = await putTextObject({
       bucket: output.bucket,
@@ -3128,6 +3172,7 @@ export const _private = {
   buildOneRowSeedCsv,
   buildLeePermitDetailBatchMessages,
   buildPropertyFirstPermitEligibility,
+  shouldSkipIneligiblePropertyFirstParcel,
   buildPropertyFirstStateKey,
   buildPropertyFirstTarget,
   createInitialLeePropertyFirstSeedFeederState,


### PR DESCRIPTION
## What
Server-side half of the on-demand→Neon permit fix. Flag-gated on a new `onDemand` boolean so **only** the single-property on-demand path changes; bulk/seed-feeder behavior is byte-identical.

## Why
The on-demand permit path loads to Neon by default, but two gates silently discarded it:
- **Gate A (eligibility):** on-demand messages carry only a parcel id, so `shouldEnqueue` is false and the parcel is skipped.
- **Gate B (link rollback):** the permit upsert + appraiser-link run in one transaction; `linkPropertyFirstPermits` throws when no `lee_appraiser` property matches, rolling back the upsert. S3 artifacts survived, Neon got nothing.

## Change
- `validateMessage` accepts an optional `onDemand` boolean (absent → current behavior).
- Gate A: `shouldSkipIneligiblePropertyFirstParcel({eligibility, onDemand})` returns false when `onDemand` (always harvest).
- Gate B: `linkPropertyFirstPermits(..., onDemand)` returns zero link counters instead of throwing when `onDemand` and no property matches, so `commit` persists the upsert. Non-onDemand still throws exactly as before. Transaction not reordered/split.

## Safety / deploy
Additive, default-preserving. Idempotent upsert on `(source_system, source_record_key)` unchanged. **Deploy is a separate surgical `aws lambda update-function-code`** — NOT a CFN deploy (worker shared with Lee prod). Pairs with elephant-mcp #30 (which sets `onDemand:true`); the old worker ignores the extra field, so ordering is safe.

## Tests
Worker suite 53 passed (target file 10→13): Gate A bypass, Gate B non-throw+commit for on-demand vs throw otherwise, and `onDemand` validation.