### PR TITLE
Publish canonical county catalog

### DIFF
--- a/.agents/skills/county-ingest-run/SKILL.md
+++ b/.agents/skills/county-ingest-run/SKILL.md
@@ -187,6 +187,27 @@ each load/index refresh window:
 The coverage JSON is a public Filebase/IPFS contract only; do not point donphan, Miranda, or end
 users at an AWS S3 URL for coverage. S3 remains internal to the ingestion/load orchestration.
 
+After both public pointers are verified, upsert the county in the repository-owned canonical
+catalog and include that catalog change in the county publication PR:
+
+```bash
+npm run catalog:update -- \
+  --county-key "<lower-kebab-county>" \
+  --county-name "<Display Name>" \
+  --state-code "<STATE>" \
+  --county-fips "<five-digit FIPS>" \
+  --query-table-url "<public IPNS URL>" \
+  --dataset-coverage-url "<public IPNS URL>" \
+  --updated-at "<latest dataset timestamp>"
+```
+
+The updater reads both required public artifacts back and rejects a coverage/county mismatch.
+Use `--permit-query-table-url` when a separate permit table is published. The tracked
+`catalog/published-counties.json` file is the authoritative enumeration contract consumed by
+Elephant MCP `listPublishedCounties` and scheduled consumers such as Watchog. Never add a county
+before its public URLs have been read back and validated. A county publication is incomplete
+until the catalog PR is merged.
+
 ## 6. Failure handling
 
 - DLQ messages: inspect, fix root cause, redrive (`scripts/auto-fix-queue.sh`,

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,0 +1,26 @@
+# Published county catalog
+
+`published-counties.json` is the canonical, public enumeration of Oracle county
+datasets. Add or update an entry only after its public query-table and coverage
+URLs have been read back successfully.
+
+Update it with:
+
+```bash
+npm run catalog:update -- \
+  --county-key "lee" \
+  --county-name "Lee" \
+  --state-code "FL" \
+  --county-fips "12071" \
+  --query-table-url "https://..." \
+  --dataset-coverage-url "https://..." \
+  --updated-at "2026-07-24T00:00:00.000Z"
+```
+
+The updater reads back the public query table and coverage artifacts, verifies
+the coverage county identity, validates URLs and timestamps, rejects duplicate
+keys/FIPS codes, and sorts entries deterministically. Coverage is mandatory;
+`permitQueryTableUrl` may be `null`.
+
+Consumers should use Elephant MCP `listPublishedCounties` instead of coupling
+directly to this repository path.

--- a/catalog/published-counties.json
+++ b/catalog/published-counties.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-07-24T00:00:00.000Z",
+  "counties": [
+    {
+      "countyKey": "lee",
+      "countyName": "Lee",
+      "stateCode": "FL",
+      "countyFips": "12071",
+      "status": "published",
+      "queryTableUrl": "https://ipfs.filebase.io/ipns/k51qzi5uqu5djd4ohcf3qm87dhlt0e270xw8ejhkyia62edr76uj0u05hrf7m5",
+      "datasetCoverageUrl": "https://k51qzi5uqu5dimw0elyh4agbtqe7v2fzp0jcd7b1bcu8kxs0hml7yu1no0z0vd.ipns.dweb.link/",
+      "permitQueryTableUrl": null,
+      "updatedAt": "2026-07-07T10:53:46.288Z"
+    },
+    {
+      "countyKey": "miami-dade",
+      "countyName": "Miami-Dade",
+      "stateCode": "FL",
+      "countyFips": "12086",
+      "status": "published",
+      "queryTableUrl": "https://ipfs.filebase.io/ipns/k51qzi5uqu5dgqktver4htb060qxfnaytjhybcxlfkp22vtgygbx2lb4t1h1xs",
+      "datasetCoverageUrl": "https://k51qzi5uqu5djj45hvhz6z2dnsdg6pkgucds99t0f78d5gmwu19bfv8o9tygno.ipns.dweb.link/",
+      "permitQueryTableUrl": null,
+      "updatedAt": "2026-07-07T09:58:45.095Z"
+    },
+    {
+      "countyKey": "orange",
+      "countyName": "Orange",
+      "stateCode": "FL",
+      "countyFips": "12095",
+      "status": "published",
+      "queryTableUrl": "https://ipfs.filebase.io/ipns/k51qzi5uqu5dhgte20ho86rzg5b7h0ght3a2js5wz0t55i96aaf1d12wpl8efn",
+      "datasetCoverageUrl": "https://k51qzi5uqu5dj8n2f8nowh8kts53rvpr62zfj0mz9izc11rfzv56q7m4161lg7.ipns.dweb.link/",
+      "permitQueryTableUrl": null,
+      "updatedAt": "2026-07-06T16:28:01.347Z"
+    },
+    {
+      "countyKey": "palm-beach",
+      "countyName": "Palm Beach",
+      "stateCode": "FL",
+      "countyFips": "12099",
+      "status": "published",
+      "queryTableUrl": "https://ipfs.filebase.io/ipns/k51qzi5uqu5dlu7hx158su5palzzxdbl6zcm8ojh7645bxisxs0cf0s158h6h3",
+      "datasetCoverageUrl": "https://k51qzi5uqu5djwga4mcd8nx1gbwy4o9rks3gkoe1u5py5wi9tieea7h44nh4g2.ipns.dweb.link/",
+      "permitQueryTableUrl": null,
+      "updatedAt": "2026-07-02T14:21:44.544Z"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "install-workspaces": "npm install --workspaces",
+    "catalog:update": "node scripts/update-published-county-catalog.mjs",
     "query-post-logs": "node scripts/query_post_logs.js",
     "update-elephant-cli": "npm install @elephant-xyz/cli@latest --workspace=prepare/lambdas/downloader --workspace=workflow/lambdas/submit --workspace=workflow/lambdas/pre --workspace=workflow/lambdas/mvl"
   },

--- a/scripts/update-published-county-catalog.mjs
+++ b/scripts/update-published-county-catalog.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const COUNTY_KEY_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const STATE_CODE_PATTERN = /^[A-Z]{2}$/;
+const COUNTY_FIPS_PATTERN = /^\d{5}$/;
+const ISO_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+
+/**
+ * @typedef {Object} PublishedCounty
+ * @property {string} countyKey Stable lower-kebab county identifier.
+ * @property {string} countyName Human-readable county name.
+ * @property {string} stateCode Two-letter uppercase state code.
+ * @property {string} countyFips Stable five-digit US county FIPS code.
+ * @property {"published"} status Publication state.
+ * @property {string} queryTableUrl Public query-table Parquet URL.
+ * @property {string} datasetCoverageUrl Public dataset coverage URL.
+ * @property {string | null} permitQueryTableUrl Public permit query-table URL.
+ * @property {string} updatedAt ISO-8601 timestamp of the latest published data change.
+ */
+
+/**
+ * @typedef {Object} PublishedCountyCatalog
+ * @property {"1.0"} schemaVersion Catalog schema version.
+ * @property {string} generatedAt ISO-8601 catalog generation timestamp.
+ * @property {PublishedCounty[]} counties Published counties sorted by countyKey.
+ */
+
+/**
+ * Normalize a county key to lower-kebab form.
+ *
+ * @param {string} value Raw county name/key.
+ * @returns {string} Normalized county key.
+ */
+export function normalizeCountyKey(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Assert that a value is an HTTP(S) URL.
+ *
+ * @param {unknown} value Candidate URL.
+ * @param {string} fieldName Field name for errors.
+ * @param {boolean} nullable Whether null is accepted.
+ * @returns {asserts value is string | null}
+ */
+function assertUrl(value, fieldName, nullable = false) {
+  if (nullable && value === null) return;
+  if (typeof value !== "string") {
+    throw new Error(
+      `${fieldName} must be an HTTP(S) URL${nullable ? " or null" : ""}`,
+    );
+  }
+  const parsed = new URL(value);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${fieldName} must use http or https`);
+  }
+}
+
+/**
+ * Validate and return a canonical published-county catalog.
+ *
+ * @param {unknown} input Untrusted parsed JSON.
+ * @returns {PublishedCountyCatalog} Validated, deterministically sorted catalog.
+ */
+export function validateCatalog(input) {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new Error("catalog must be a JSON object");
+  }
+  const catalog = /** @type {Record<string, unknown>} */ (input);
+  if (catalog.schemaVersion !== "1.0") {
+    throw new Error("schemaVersion must be '1.0'");
+  }
+  if (
+    typeof catalog.generatedAt !== "string" ||
+    !ISO_TIMESTAMP_PATTERN.test(catalog.generatedAt)
+  ) {
+    throw new Error("generatedAt must be an ISO-8601 UTC timestamp");
+  }
+  if (!Array.isArray(catalog.counties)) {
+    throw new Error("counties must be an array");
+  }
+
+  /** @type {Set<string>} */
+  const seen = new Set();
+  /** @type {Set<string>} */
+  const seenFips = new Set();
+  const counties = catalog.counties.map((raw, index) => {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      throw new Error(`counties[${index}] must be an object`);
+    }
+    const row = /** @type {Record<string, unknown>} */ (raw);
+    const countyKey =
+      typeof row.countyKey === "string"
+        ? normalizeCountyKey(row.countyKey)
+        : "";
+    if (!COUNTY_KEY_PATTERN.test(countyKey) || row.countyKey !== countyKey) {
+      throw new Error(
+        `counties[${index}].countyKey must be normalized lower-kebab`,
+      );
+    }
+    if (seen.has(countyKey)) {
+      throw new Error(`duplicate countyKey '${countyKey}'`);
+    }
+    seen.add(countyKey);
+    if (typeof row.countyName !== "string" || row.countyName.trim() === "") {
+      throw new Error(`counties[${index}].countyName is required`);
+    }
+    if (
+      typeof row.stateCode !== "string" ||
+      !STATE_CODE_PATTERN.test(row.stateCode)
+    ) {
+      throw new Error(
+        `counties[${index}].stateCode must be two uppercase letters`,
+      );
+    }
+    if (
+      typeof row.countyFips !== "string" ||
+      !COUNTY_FIPS_PATTERN.test(row.countyFips)
+    ) {
+      throw new Error(`counties[${index}].countyFips must be five digits`);
+    }
+    if (seenFips.has(row.countyFips)) {
+      throw new Error(`duplicate countyFips '${row.countyFips}'`);
+    }
+    seenFips.add(row.countyFips);
+    if (row.status !== "published") {
+      throw new Error(`counties[${index}].status must be 'published'`);
+    }
+    assertUrl(row.queryTableUrl, `counties[${index}].queryTableUrl`);
+    assertUrl(row.datasetCoverageUrl, `counties[${index}].datasetCoverageUrl`);
+    assertUrl(
+      row.permitQueryTableUrl,
+      `counties[${index}].permitQueryTableUrl`,
+      true,
+    );
+    if (
+      typeof row.updatedAt !== "string" ||
+      !ISO_TIMESTAMP_PATTERN.test(row.updatedAt)
+    ) {
+      throw new Error(
+        `counties[${index}].updatedAt must be an ISO-8601 UTC timestamp`,
+      );
+    }
+    return /** @type {PublishedCounty} */ ({
+      countyKey,
+      countyName: row.countyName.trim(),
+      stateCode: row.stateCode,
+      countyFips: row.countyFips,
+      status: "published",
+      queryTableUrl: row.queryTableUrl,
+      datasetCoverageUrl: row.datasetCoverageUrl,
+      permitQueryTableUrl: row.permitQueryTableUrl,
+      updatedAt: row.updatedAt,
+    });
+  });
+
+  return {
+    schemaVersion: "1.0",
+    generatedAt: catalog.generatedAt,
+    counties: counties.sort((a, b) => a.countyKey.localeCompare(b.countyKey)),
+  };
+}
+
+/**
+ * Insert or replace one county and return a deterministic catalog.
+ *
+ * @param {PublishedCountyCatalog} catalog Existing validated catalog.
+ * @param {PublishedCounty} county County to upsert.
+ * @param {string} generatedAt Catalog generation timestamp.
+ * @returns {PublishedCountyCatalog} Updated validated catalog.
+ */
+export function upsertCounty(catalog, county, generatedAt) {
+  const counties = catalog.counties.filter(
+    (entry) =>
+      entry.countyKey !== county.countyKey &&
+      entry.countyFips !== county.countyFips,
+  );
+  counties.push(county);
+  return validateCatalog({
+    schemaVersion: "1.0",
+    generatedAt,
+    counties,
+  });
+}
+
+/**
+ * Parse CLI flags in `--name value` form.
+ *
+ * @param {string[]} argv Process arguments excluding node/script.
+ * @returns {Record<string, string>} Parsed flags.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string>} */
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(
+        `Expected --flag value pairs; invalid argument '${flag ?? ""}'`,
+      );
+    }
+    result[flag.slice(2)] = value;
+  }
+  return result;
+}
+
+/**
+ * Convert optional CLI URL values to null.
+ *
+ * @param {string | undefined} value Raw optional URL.
+ * @returns {string | null} URL or null.
+ */
+function optionalUrl(value) {
+  return value && value.trim() !== "" ? value.trim() : null;
+}
+
+/**
+ * Verify both required public artifacts before admitting a county.
+ *
+ * @param {PublishedCounty} county Candidate county entry.
+ * @param {(input: string | URL | Request, init?: RequestInit) => Promise<Response>} fetchImpl Fetch implementation.
+ * @returns {Promise<void>}
+ */
+export async function verifyPublishedCountyArtifacts(
+  county,
+  fetchImpl = fetch,
+) {
+  const queryResponse = await fetchImpl(county.queryTableUrl, {
+    method: "HEAD",
+    redirect: "follow",
+  });
+  if (!queryResponse.ok) {
+    throw new Error(
+      `query table verification failed with HTTP ${queryResponse.status}`,
+    );
+  }
+
+  const coverageResponse = await fetchImpl(county.datasetCoverageUrl, {
+    redirect: "follow",
+  });
+  if (!coverageResponse.ok) {
+    throw new Error(
+      `dataset coverage verification failed with HTTP ${coverageResponse.status}`,
+    );
+  }
+  const coverage = /** @type {unknown} */ (await coverageResponse.json());
+  if (
+    typeof coverage !== "object" ||
+    coverage === null ||
+    Array.isArray(coverage) ||
+    typeof (/** @type {Record<string, unknown>} */ (coverage).county) !==
+      "string"
+  ) {
+    throw new Error("dataset coverage response is missing county identity");
+  }
+  const coverageCounty = normalizeCountyKey(
+    /** @type {string} */ (
+      /** @type {Record<string, unknown>} */ (coverage).county
+    ),
+  );
+  if (coverageCounty !== county.countyKey) {
+    throw new Error(
+      `dataset coverage county '${coverageCounty}' does not match '${county.countyKey}'`,
+    );
+  }
+}
+
+/**
+ * Run the catalog update CLI.
+ *
+ * @param {string[]} argv Process arguments excluding node/script.
+ * @returns {Promise<void>}
+ */
+export async function main(argv) {
+  const args = parseArgs(argv);
+  const catalogPath = args.catalog ?? "catalog/published-counties.json";
+  const now = args["generated-at"] ?? new Date().toISOString();
+  const required = [
+    "county-key",
+    "county-name",
+    "state-code",
+    "county-fips",
+    "query-table-url",
+    "dataset-coverage-url",
+    "updated-at",
+  ];
+  for (const key of required) {
+    if (!args[key]) throw new Error(`--${key} is required`);
+  }
+
+  const catalog = validateCatalog(
+    JSON.parse(await readFile(catalogPath, "utf8")),
+  );
+  const county = /** @type {PublishedCounty} */ ({
+    countyKey: normalizeCountyKey(args["county-key"]),
+    countyName: args["county-name"],
+    stateCode: args["state-code"].toUpperCase(),
+    countyFips: args["county-fips"],
+    status: "published",
+    queryTableUrl: args["query-table-url"],
+    datasetCoverageUrl: args["dataset-coverage-url"],
+    permitQueryTableUrl: optionalUrl(args["permit-query-table-url"]),
+    updatedAt: args["updated-at"],
+  });
+  validateCatalog({
+    schemaVersion: "1.0",
+    generatedAt: now,
+    counties: [county],
+  });
+  await verifyPublishedCountyArtifacts(county);
+  const updated = upsertCounty(catalog, county, now);
+  await writeFile(catalogPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
+  process.stdout.write(
+    `Updated ${catalogPath}: ${updated.counties.length} published counties\n`,
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/update-published-county-catalog.mjs
+++ b/scripts/update-published-county-catalog.mjs
@@ -180,10 +180,24 @@ export function validateCatalog(input) {
  * @returns {PublishedCountyCatalog} Updated validated catalog.
  */
 export function upsertCounty(catalog, county, generatedAt) {
+  const keyMatch = catalog.counties.find(
+    (entry) => entry.countyKey === county.countyKey,
+  );
+  if (keyMatch !== undefined && keyMatch.countyFips !== county.countyFips) {
+    throw new Error(
+      `countyKey '${county.countyKey}' is already assigned to FIPS '${keyMatch.countyFips}'`,
+    );
+  }
+  const fipsMatch = catalog.counties.find(
+    (entry) => entry.countyFips === county.countyFips,
+  );
+  if (fipsMatch !== undefined && fipsMatch.countyKey !== county.countyKey) {
+    throw new Error(
+      `countyFips '${county.countyFips}' is already assigned to '${fipsMatch.countyKey}'`,
+    );
+  }
   const counties = catalog.counties.filter(
-    (entry) =>
-      entry.countyKey !== county.countyKey &&
-      entry.countyFips !== county.countyFips,
+    (entry) => entry.countyKey !== county.countyKey,
   );
   counties.push(county);
   return validateCatalog({

--- a/scripts/update-published-county-catalog.mjs
+++ b/scripts/update-published-county-catalog.mjs
@@ -205,7 +205,11 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 2) {
     const flag = argv[index];
     const value = argv[index + 1];
-    if (!flag?.startsWith("--") || value === undefined) {
+    if (
+      !flag?.startsWith("--") ||
+      value === undefined ||
+      value.startsWith("--")
+    ) {
       throw new Error(
         `Expected --flag value pairs; invalid argument '${flag ?? ""}'`,
       );
@@ -273,6 +277,18 @@ export async function verifyPublishedCountyArtifacts(
     throw new Error(
       `dataset coverage county '${coverageCounty}' does not match '${county.countyKey}'`,
     );
+  }
+
+  if (county.permitQueryTableUrl !== null) {
+    const permitResponse = await fetchImpl(county.permitQueryTableUrl, {
+      method: "HEAD",
+      redirect: "follow",
+    });
+    if (!permitResponse.ok) {
+      throw new Error(
+        `permit query table verification failed with HTTP ${permitResponse.status}`,
+      );
+    }
   }
 }
 

--- a/tests/published-county-catalog.test.mjs
+++ b/tests/published-county-catalog.test.mjs
@@ -74,6 +74,32 @@ describe("published county catalog", () => {
     ]);
   });
 
+  it("rejects a FIPS code already assigned to another county", () => {
+    expect(() =>
+      upsertCounty(
+        validateCatalog(baseCatalog),
+        {
+          ...baseCatalog.counties[0],
+          countyKey: "orange",
+        },
+        "2026-07-24T10:01:00.000Z",
+      ),
+    ).toThrow("countyFips '12071' is already assigned to 'lee'");
+  });
+
+  it("rejects changing the FIPS identity of an existing county", () => {
+    expect(() =>
+      upsertCounty(
+        validateCatalog(baseCatalog),
+        {
+          ...baseCatalog.counties[0],
+          countyFips: "12095",
+        },
+        "2026-07-24T10:01:00.000Z",
+      ),
+    ).toThrow("countyKey 'lee' is already assigned to FIPS '12071'");
+  });
+
   it("rejects duplicate county keys", () => {
     expect(() =>
       validateCatalog({

--- a/tests/published-county-catalog.test.mjs
+++ b/tests/published-county-catalog.test.mjs
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeCountyKey,
+  upsertCounty,
+  validateCatalog,
+  verifyPublishedCountyArtifacts,
+} from "../scripts/update-published-county-catalog.mjs";
+
+const baseCatalog = {
+  schemaVersion: "1.0",
+  generatedAt: "2026-07-24T00:00:00.000Z",
+  counties: [
+    {
+      countyKey: "lee",
+      countyName: "Lee",
+      stateCode: "FL",
+      countyFips: "12071",
+      status: "published",
+      queryTableUrl: "https://example.com/lee.parquet",
+      datasetCoverageUrl: "https://example.com/lee-coverage.json",
+      permitQueryTableUrl: null,
+      updatedAt: "2026-07-23T00:00:00.000Z",
+    },
+  ],
+};
+
+describe("published county catalog", () => {
+  it("validates the tracked canonical catalog", async () => {
+    const tracked = JSON.parse(
+      await readFile(resolve("catalog/published-counties.json"), "utf8"),
+    );
+
+    const result = validateCatalog(tracked);
+
+    expect(result.counties).toHaveLength(4);
+    expect(result.counties.map((county) => county.countyKey)).toEqual([
+      "lee",
+      "miami-dade",
+      "orange",
+      "palm-beach",
+    ]);
+  });
+
+  it("normalizes county keys", () => {
+    expect(normalizeCountyKey("  Miami Dade  ")).toBe("miami-dade");
+    expect(normalizeCountyKey("Palm_Beach")).toBe("palm-beach");
+  });
+
+  it("upserts a county and keeps entries sorted", () => {
+    const updated = upsertCounty(
+      validateCatalog(baseCatalog),
+      {
+        countyKey: "alameda",
+        countyName: "Alameda",
+        stateCode: "CA",
+        countyFips: "06001",
+        status: "published",
+        queryTableUrl: "https://example.com/alameda.parquet",
+        datasetCoverageUrl: "https://example.com/alameda-coverage.json",
+        permitQueryTableUrl: null,
+        updatedAt: "2026-07-24T10:00:00.000Z",
+      },
+      "2026-07-24T10:01:00.000Z",
+    );
+
+    expect(updated.generatedAt).toBe("2026-07-24T10:01:00.000Z");
+    expect(updated.counties.map((county) => county.countyKey)).toEqual([
+      "alameda",
+      "lee",
+    ]);
+  });
+
+  it("rejects duplicate county keys", () => {
+    expect(() =>
+      validateCatalog({
+        ...baseCatalog,
+        counties: [...baseCatalog.counties, baseCatalog.counties[0]],
+      }),
+    ).toThrow("duplicate countyKey 'lee'");
+  });
+
+  it("rejects published counties without coverage", () => {
+    expect(() =>
+      validateCatalog({
+        ...baseCatalog,
+        counties: [
+          {
+            ...baseCatalog.counties[0],
+            datasetCoverageUrl: null,
+          },
+        ],
+      }),
+    ).toThrow("datasetCoverageUrl must be an HTTP(S) URL");
+  });
+
+  it("rejects duplicate county FIPS identities", () => {
+    expect(() =>
+      validateCatalog({
+        ...baseCatalog,
+        counties: [
+          ...baseCatalog.counties,
+          {
+            ...baseCatalog.counties[0],
+            countyKey: "different-key",
+          },
+        ],
+      }),
+    ).toThrow("duplicate countyFips '12071'");
+  });
+
+  it("reads back artifacts and verifies the coverage county", async () => {
+    const requests = [];
+    const fetchImpl = async (url, init) => {
+      requests.push({ url: String(url), method: init?.method ?? "GET" });
+      if (init?.method === "HEAD") {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(JSON.stringify({ county: "Lee", datasets: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await verifyPublishedCountyArtifacts(
+      validateCatalog(baseCatalog).counties[0],
+      fetchImpl,
+    );
+
+    expect(requests).toEqual([
+      { url: "https://example.com/lee.parquet", method: "HEAD" },
+      { url: "https://example.com/lee-coverage.json", method: "GET" },
+    ]);
+  });
+
+  it("rejects coverage for a different county", async () => {
+    const fetchImpl = async (_url, init) =>
+      init?.method === "HEAD"
+        ? new Response(null, { status: 200 })
+        : new Response(JSON.stringify({ county: "Orange" }), { status: 200 });
+
+    await expect(
+      verifyPublishedCountyArtifacts(
+        validateCatalog(baseCatalog).counties[0],
+        fetchImpl,
+      ),
+    ).rejects.toThrow("does not match 'lee'");
+  });
+
+  it("rejects non-public query table URLs", () => {
+    expect(() =>
+      validateCatalog({
+        ...baseCatalog,
+        counties: [
+          {
+            ...baseCatalog.counties[0],
+            queryTableUrl: "file:///tmp/lee.parquet",
+          },
+        ],
+      }),
+    ).toThrow("must use http or https");
+  });
+});

--- a/tests/published-county-catalog.test.mjs
+++ b/tests/published-county-catalog.test.mjs
@@ -36,7 +36,7 @@ describe("published county catalog", () => {
 
     const result = validateCatalog(tracked);
 
-    expect(result.counties).toHaveLength(4);
+    expect(result.counties.length).toBeGreaterThan(0);
     expect(result.counties.map((county) => county.countyKey)).toEqual([
       "lee",
       "miami-dade",
@@ -134,6 +134,28 @@ describe("published county catalog", () => {
       { url: "https://example.com/lee.parquet", method: "HEAD" },
       { url: "https://example.com/lee-coverage.json", method: "GET" },
     ]);
+  });
+
+  it("verifies an optional permit query table", async () => {
+    const requests = [];
+    const fetchImpl = async (url, init) => {
+      requests.push({ url: String(url), method: init?.method ?? "GET" });
+      if (init?.method === "HEAD") {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(JSON.stringify({ county: "Lee" }), { status: 200 });
+    };
+    const county = {
+      ...validateCatalog(baseCatalog).counties[0],
+      permitQueryTableUrl: "https://example.com/lee-permits.parquet",
+    };
+
+    await verifyPublishedCountyArtifacts(county, fetchImpl);
+
+    expect(requests.at(-1)).toEqual({
+      url: "https://example.com/lee-permits.parquet",
+      method: "HEAD",
+    });
   });
 
   it("rejects coverage for a different county", async () => {


### PR DESCRIPTION
## Summary
- add an Oracle-owned catalog of counties with verified query and coverage artifacts
- provide a deterministic updater that validates FIPS identities and reads public artifacts back before publishing
- document the county publication gate for MCP and Watchog consumers

## Test plan
- [x] `npm run test` (579 tests)
- [x] `npm run test -- tests/published-county-catalog.test.mjs`
- [x] `npm run typecheck`
- [x] changed-file Prettier checks


Made with [Cursor](https://cursor.com)