### PR TITLE
Sync Overture skill lock and lexicon tracking

### DIFF
--- a/.agents/skills/overture-places-ingest/SKILL.md
+++ b/.agents/skills/overture-places-ingest/SKILL.md
@@ -1,395 +1,297 @@
 ---
 name: overture-places-ingest
-description: Ingest Overture Maps places (business/POI points with a controlled category taxonomy) for a county from the public Overture S3 release, clipped to the county boundary, into the `business_locations` tables in the elephant query DB and published as a per-county places table on IPFS. Use when a county needs business-category data, when refreshing a monthly Overture release, or when asked where business type/category data comes from.
+description: Ingest Overture Maps places for a county with taxonomy, boundary, source-licence, Neon coverage, and IPFS publication gates. Use when a county needs business/POI category data, when refreshing an Overture release, or when publishing a county places table.
 metadata:
   author: elephant-xyz
 ---
 
 # Overture Places Ingest
 
-Global data source, county-scoped at extraction — same shape as `sunbiz-corporate-ingest`
-(statewide source, county-scoped by ZIP) and `bbb-harvest` (national source, county-agnostic
-crawl). Overture is the ONLY source in the pipeline that carries a business **category**:
-Sunbiz has no industry field at all (Florida does not collect one at incorporation) and BBB
-is a contractor directory by selection (2,103 of 2,810 FL profiles are construction trades,
-0 food). Nothing else across the ~70 public tables supplies a category taxonomy.
+Ingest Overture Maps places as county-scoped business/POI locations. Overture is the
+pipeline's category source: Sunbiz describes legal entities, BBB is selected for
+contractor reputation, and neither is a general location taxonomy.
 
-Design decisions and their rationale — why a new `business_location` concept rather than
-`companies` or the lexicon's `nearby_location`, why `expected_count` is NULL, and the
-attribution obligation — are in `docs/overture-places-design.md`. **Read that first**; this
-skill is the runbook, that doc is the reasoning.
+> **Implementation status:** Lee County, Florida is verified end to end through
+> extraction, Neon load, validation, and dedicated Filebase/IPNS publication. The
+> implemented extract/export/validation code is in `oracle-node`; the places schema,
+> bulk-loader track, coverage upsert, and Filebase uploader are in
+> `elephant-query-db`. Parcel-link population, counties other than Lee, and an
+> automated monthly refresh remain unimplemented.
 
-> **STATUS: LEE PILOT PUBLISHED.** Extract/export/validate/catalog/query-db load scripts exist.
-> Lee `2026-07-22.0` clipped to **40,191** (baseline 40,190). Licence gate: `osm` absent;
-> `Overture` / `Overture-signals` allowed by human decision 2026-08-12. PII gate **2026-08-12:
-> publish as-is**, including business `emails` and `phones`. Lee places Filebase/IPNS publish
-> completed. Parcel linking is not run.
+## Non-negotiable gates
 
-## Source facts (verified 2026-08-12)
+1. Resolve the Overture release from its STAC catalog and pin the resolved release in
+   the run record. Never let a rerun silently move to a newer release.
+2. Clip with a Census TIGER/Line county polygon: cheap bounding-box pruning first,
+   then `ST_Within`. A bounding-box count is diagnostic only and is never publishable.
+3. Key category logic on `taxonomy.hierarchy`. Never key new behavior on deprecated
+   `categories.primary`; retain it only as `legacy_category_primary` while the source
+   still supplies it.
+4. Run the mandatory, case-insensitive source-dataset gate after extraction and again
+   against the loaded source rows immediately before publication. `osm` and every
+   unknown provider are hard stops.
+5. Set `oracle_dataset_coverage.expected_count` to `NULL`. Overture supplies a
+   numerator, not an authoritative denominator for all county businesses.
+6. Publish places from a separate per-county Filebase bucket and IPNS name. Include
+   the required root `NOTICE.txt` and machine-readable attribution in `index.json`.
+7. Never commit extracted JSONL, Parquet, credentials, or generated publish artifacts.
 
-- Release `2026-07-22.0` at `s3://overturemaps-us-west-2/release/<release>/theme=places/type=place/*`.
-  Public bucket, **no credentials**, no rate limit, monthly cadence. Azure mirror exists.
-- Read with **DuckDB** (`LOAD spatial; LOAD httpfs; SET s3_region='us-west-2';`). DuckDB is
-  not currently a dependency of any repo in this workspace — adding it is part of the work.
-- Do **not** hard-code the release date in the scripts. Overture publishes a STAC catalog for
-  release discovery; pin the resolved release into the run record so a re-run is reproducible.
-- Observed volumes (**UNVERIFIED** beyond the original probe): Lee **40,190** places clipped to
-  the county boundary in ~4 s; Orange **104,223** and Miami-Dade **154,075** by _bounding box_,
-  which runs a few percent high. A two-county bbox query took 79 s. Never publish a bbox count.
+## Taxonomy contract
 
-### ⚠️ `categories` is deprecated and disappears in the September 2026 release
+Overture deprecated `categories`; it is removed beginning with the September 2026
+release. Store and query:
 
-The original `categories.primary` property — the 2,117-entry vocabulary the scoping research
-measured (1,244 distinct values in Lee) — **is deprecated and will be REMOVED in the September
-2026 release**, replaced by `taxonomy` and `basic_category`. Given the date, an implementation
-that keys on `categories.primary` breaks roughly one release after it ships.
+- `taxonomy.primary`: the most specific current label.
+- `taxonomy.hierarchy`: the source-provided ordered L0-to-primary path. This is the
+  canonical roll-up field and must not be reconstructed from labels.
+- `taxonomy.alternates`: preserve for inspection, but do not count alternates as
+  primary-category membership.
+- `basic_category`: coarse Overture label for filtering and map display.
+- `categories.primary`: temporary compatibility field named
+  `legacy_category_primary` only.
 
-Key on the new properties:
+Stamp every row with `overture_release`. Overture taxonomy changes quarterly, so a
+category is meaningful only with its release.
 
-- `taxonomy.primary` — most specific category label (~2,300-entry OPC taxonomy).
-- `taxonomy.hierarchy` — ordered L0→primary path, e.g.
-  `[food_and_drink, restaurant, casual_eatery, gas_station_sushi]`. **This is the field to
-  aggregate on**; do not re-derive a hierarchy from the label.
-- `taxonomy.alternate` — other plausible labels. Store them, but they are **not reliable for
-  analysis**: 80 Lee nail salons also carry `beauty_salon`. Any consumer counting by category
-  must count `taxonomy.primary` only.
-- `basic_category` — ~280-300 "cognitively basic" labels (`hotel`, `cafe`, `museum`). Use for
-  coarse filtering and map iconography.
+### Hosted-service classification
 
-Keep `categories.primary` in a `legacy_category_primary` column while both exist, so the
-scoping numbers stay reconcilable, and drop the column once September lands. The taxonomy
-itself moves on a quarterly cycle (March/June/September/December): the July 2026 redesign
-renamed 407 categories, removed 80 (with redirect rules), reparented 482 and **repathed
-2,108**. Stamp every row with the release it was extracted from — category values are only
-meaningful relative to a release.
+`config/hosted-service-categories.txt` contains exactly five human-reviewed, full
+`taxonomy.hierarchy` paths observed in the Lee `2026-07-22.0` extract. Match the
+complete path, set `is_hosted_service = true`, and stamp
+`hosted_service_rule = 'hosted-service-categories@<release>'`.
 
-## 1. Resolve the county boundary
+The flag is advisory: preserve every place and let consumers decide whether to exclude
+hosted services. Do not claim or generate a 250-entry rebuild. The earlier "~250"
+number came from deprecated flat `categories.primary` values and was never validated
+as a hierarchy-path list.
 
-Overture is global; this pipeline is per-county; `oracle_dataset_coverage` is keyed
-`(county, source)`. Extraction MUST be clipped to a boundary, not a bounding box.
+## 1. Resolve and pin the release
 
-- Use **Census TIGER/Line county boundaries** (`tl_<year>_us_county`), selected by the county
-  FIPS already recorded in `catalog/published-counties.json` (Lee `12071`, Orange `12095`,
-  Miami-Dade `12086`, Palm Beach `12099`).
-- TIGER boundaries are legal/statistical extents and do **not** exactly match an appraiser's
-  parcel-roll extent. That is acceptable — a place is not a parcel — but record the TIGER
-  vintage in the run record so a later count change can be attributed to a boundary change
-  rather than to Overture.
-- Two stages, both required: filter on the parquet `bbox` struct first (cheap partition
-  pruning), then `ST_Within` against the boundary polygon. The bbox stage is an optimisation,
-  never the answer.
+The public places theme is:
 
-**A place outside every Elephant county is not ingested.** There is no "unassigned" bucket —
-Overture is global and that bucket would be unbounded. **Tie-break rule: assign by geometry.**
-Where a place's point falls in county A but its Overture `addresses[0]` names county B, county
-A owns it and the discrepancy is recorded in `source_payload`. Without a stated rule two
-counties will both claim border places and the coverage counts will not reconcile.
+```text
+s3://overturemaps-us-west-2/release/<release>/theme=places/type=place/*
+```
 
-## 2. Extract
+Discover from STAC, review the selected release, then pass it explicitly:
+
+```bash
+curl -s https://stac.overturemaps.org/catalog.json |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["latest"])'
+
+node scripts/extract-overture-places.mjs \
+  --county lee \
+  --county-fips 12071 \
+  --release 2026-07-22.0 \
+  --boundary-source tiger/tl_2024_us_county \
+  --output-dir downloads/overture-places/lee/2026-07-22.0
+```
+
+The extractor can discover STAC when `--release` is omitted, but the resolved ID,
+catalog URL, retrieval time, and TIGER vintage must still be written to
+`manifest/summary.json`. Reproduction commands always use the pinned release.
+
+## 2. Clip to the county boundary
+
+Use the five-digit county FIPS from the county catalog. Lee is `12071`. Select that
+`GEOID` from a pinned TIGER/Line county shapefile.
+
+The required two-stage predicate is implemented in
+`scripts/extract-county-places.sql`:
+
+1. compare the source `bbox` to the county extent to prune Parquet reads;
+2. require `ST_Within(place.geometry, county.geometry)` for county membership.
+
+Assign border records by geometry. If `addresses[0]` names a different county, the
+geometry county owns the record and the discrepancy remains in `source_payload`.
+
+Run a counts-only probe before writing JSONL:
 
 ```bash
 node scripts/extract-overture-places.mjs \
-  --county lee --county-fips 12071 \
+  --county lee \
+  --county-fips 12071 \
   --release 2026-07-22.0 \
   --boundary-source tiger/tl_2024_us_county \
-  --output-s3-uri s3://<env-bucket>/overture-places/<county>/<release>/
+  --counts-only \
+  --output-dir downloads/overture-places/lee/probe
 ```
 
-Reference query in `scripts/extract-county-places.sql`. Output is chunked JSONL plus a
-`manifest/summary.json` carrying the counters that become the run record (§4) — the same
-`profiles/` + `manifest/summary.json` layout `bbb-harvest` produces.
+Keep every clipped place. Overture already applies its own minimum confidence; another
+extraction threshold would vary coverage by provider.
 
-**Keep every place. Do not filter by `confidence` at extraction.** Overture already drops
-places scoring ≤ 0.2, and confidence is explicitly _not calibrated across providers_ — a
-second threshold here would silently vary by which provider happens to dominate a county.
-Store the score and let consumers threshold. Same reasoning as the pipeline ground rule that
-raw HTML is always captured and unmapped fields are preserved.
+## 3. Enforce the source/licence gate
 
-### ⚠️ Assert the source datasets, every run
+Canonical comparison is case-insensitive so live values such as `Microsoft`,
+`AllThePlaces`, and `RenderSEO` match their approved canonical names. The approved set
+is the original nine attribution-page providers plus two human-approved Overture
+lineage values:
 
-Places carries **no OpenStreetMap data** and therefore none of the ODbL share-alike
-obligations — that is the whole reason this source is publishable. That property is not
-guaranteed forever, and Overture's bridge-file documentation already lists OSM as a bridged
-source for the places theme even though the attribution page does not. So make it a gate, not
-an assumption:
-
-```sql
-SELECT DISTINCT s.dataset FROM business_location_sources s WHERE ...
+```text
+meta
+microsoft
+foursquare
+pinmeto
+krick
+renderseo
+dac
+brightquery
+alltheplaces
+overture
+overture-signals
 ```
 
-must be a subset of `meta, microsoft, foursquare, pinmeto, krick, rendersEO, dac, brightquery,
-alltheplaces, Overture, Overture-signals`. The first nine were **VERIFIED** against the
-Overture attribution page 2026-08-12. `Overture` and `Overture-signals` are Overture's own
-lineage, **allowed by human decision 2026-08-12** — not OSM and not an unknown third-party
-licence. **If `osm` — or any other unknown dataset — appears, stop and do not publish.** A new
-provider may carry a different licence and the published NOTICE would be wrong.
+`Overture` and `Overture-signals` were approved by human decision on 2026-08-12 as
+Overture's own lineage. This decision does not authorize other new providers.
 
-## 3. Load into Neon
+Collect distinct `sources[].dataset` values from the complete clipped extract,
+lowercase only for comparison, and preserve the source spelling in stored rows. Fail
+closed:
 
-New Drizzle schema module `elephant-query-db/src/schema/places.ts`, loaded via the existing
-bulk loader with a new `--tracks places` track. All house rules from
-`query-db-loading-matching` apply unchanged: idempotent `ON CONFLICT DO UPDATE` merges,
-`sourceMetadataColumns()`, full payload retained in `source_payload`.
+- if `osm` appears in any casing, stop and do not load or publish;
+- if any value is outside the approved set, stop for human licence review;
+- never auto-extend the allowlist from observed data.
 
-| Table                            | Grain                             | Notes                                                                                                                                |
-| -------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `business_locations`             | one row per GERS id per county    | the place itself                                                                                                                     |
-| `business_location_categories`   | one row per category              | `is_primary` flag; holds `taxonomy.alternate`                                                                                        |
-| `business_location_sources`      | one row per `sources[]` entry     | `dataset`, `record_id`, `update_time`, `confidence`, `license` — this is what makes §2's licence gate and re-identification possible |
-| `overture_place_extractions`     | one row per (county, release) run | the honest denominators; see §4                                                                                                      |
-| `business_location_parcel_links` | one row per accepted match        | **later step, not ingest**; see §5                                                                                                   |
+Repeat this gate against `business_location_sources` immediately before export/upload.
+The published NOTICE is valid only for the providers it names.
 
-Keys and indexes on `business_locations`:
+## 4. Load and reconcile in Neon
 
-- `source_system = 'overture_places'`, `source_record_key = <GERS id>`, with the mandatory
-  `uniqueIndex (source_system, source_record_key)` every other table in the schema carries.
-  This is the merge key — there is no equivalent of the folio here, so do not invent one.
-- `geometry geometry(Point, 4326)` with a **GiST** index. PostGIS `3.5.0` is installed
-  (**VERIFIED**). Note `parcel_boundaries` stores Florida West feet (EPSG:2237), so any
-  point-in-polygon against it needs an explicit `ST_Transform` — see `src/schema/spatial.ts`.
-- btree on `(county_key, taxonomy_primary)`, `basic_category`, `normalized_name`, `address_id`,
-  and `(county_key, is_current)`.
-- `taxonomy_hierarchy text[]` with a **GIN** index so `WHERE 'restaurant' = ANY(...)` style
-  roll-ups do not scan.
+Load the chunked `places/places-part-NNNN.jsonl` and
+`manifest/summary.json` through the query DB's `--tracks places` bulk-loader track.
+The implementation uses these grains:
 
-**`address_id` is a soft link only** (`ON DELETE SET NULL`, matching `business_reputation_*`),
-resolved by `normalized_address_hash` against the shared `addresses` table. **Never write
-`company_id` at ingest** — see §5.
+- `business_locations`: one row per county/GERS place.
+- `business_location_categories`: taxonomy primary/alternate rows.
+- `business_location_sources`: provider lineage and licence evidence.
+- `overture_place_extractions`: one row per county/release run.
+- `business_location_parcel_links`: later confidence-scored bridge; do not populate
+  during ingest.
 
-> ⚠️ `addresses`, `companies`, `people` are **shared parents** across every track. The clean-
-> reload and deadlock warnings in `query-db-loading-matching` apply: never `TRUNCATE … CASCADE`
-> them, clear by `source_system` in reverse FK order, and keep the places load serial with the
-> other tracks that write shared parents.
+Use GERS ID as the source identity and idempotent upserts. Retain the complete source
+payload. Do not load places into `companies`, do not infer `company_id`, and do not
+conflate a business location with a legal entity.
 
-## 4. Coverage — `expected_count` is NULL, deliberately
+After load, assert:
 
-Upsert `oracle_dataset_coverage` with `source = 'overture_places'`:
+- loaded `business_locations` count equals the clipped manifest count;
+- no duplicate GERS IDs and no null geometry;
+- loaded distinct source datasets pass the licence gate;
+- the extraction run records release, county FIPS, TIGER vintage, bbox count, clipped
+  count, category/source/status summaries, and duration;
+- parcel links may remain zero because that later step is not part of ingest.
 
-- `ingested_count` — `business_locations` rows for the county at the current release.
-- `expected_count` — **NULL**. There is no authoritative denominator for "how many businesses
-  exist in Lee County". Overture's own count is the numerator, so using it forces a permanent
-  100%; Sunbiz counts legal entities, not locations; DBPR licence counts cover one sector.
-  NULL is the repo's sanctioned value for exactly this: `write-public-coverage-snapshot.ts`
-  emits `expected_count: null` for every non-appraisal track under the comment "unknown
-  expected counts, which means 'not ingested' rather than 'complete at zero'", and
-  `validate-publication-dry-run.ts` fails with `Coverage track … is not honestly incomplete`
-  if a non-appraisal track has a non-null one. MCP then reports `completionPercent: null`,
-  which is the truthful answer.
+Upsert `oracle_dataset_coverage` with:
 
-> ⚠️ Eight legacy rows in Neon (Lee/Miami-Dade/Orange/Palm Beach) have
-> `expected_count = ingested_count` from the original backfill, so they read as 100% complete
-> by construction. Santa Clara, the most recent county, correctly has NULL. **Copy Santa
-> Clara, not the older rows.**
+```text
+source = overture_places
+ingested_count = current business_locations count for the county/release
+expected_count = NULL
+```
 
-The real numbers go in `overture_place_extractions`, one row per (county, release):
-release id, county FIPS, TIGER boundary source and vintage, features in bbox, features after
-clip, distinct `taxonomy.primary` values, distinct `sources[].dataset` values, count by
-`operating_status`, confidence distribution, and duration.
+Do not manufacture 100% completion by setting `expected_count = ingested_count`.
 
-**Sector cross-check, recorded not enforced.** Florida DBPR's cosmetology bulk file lists
-**1,420** licensed salon establishments in Lee against Overture's **1,436** combined
-beauty/hair/nail/barber places — close agreement, and good evidence of coverage in that sector.
-Record it in the run report as a quality assertion. It is **not** an `expected_count`: it
-covers one sector and one state, and promoting it to a denominator would imply a completeness
-guarantee the number cannot support.
+## 5. Export, validate, and publish
 
-## 5. Do not conflate a place with a company
+Export current Neon rows, not the raw extract:
 
-One company operates several locations; one location hosts several companies over time.
-Collapsing them is the single most expensive mistake available here.
+```bash
+node scripts/export-overture-places-table.mjs \
+  --from-neon \
+  --env-file ../elephant-query-db/.env.local \
+  --county lee \
+  --release 2026-07-22.0 \
+  --out downloads/overture-places/lee/2026-07-22.0/publish
 
-- **Never** load places into `companies`. That table is the shared _party_ role used by
-  appraisal owners, Sunbiz registrants, BBB profiles and permit contractors (~5.5M rows); 40k
-  Lee places would pollute a parent every other track FKs into and make the company count
-  meaningless.
-- `business_locations.company_id` stays NULL at ingest. Populate it only from an explicit,
-  later name+address match step, writing a confidence and a method the way
-  `contractor_quality_scores` does (`match_confidence`, `match_method`), and only at high
-  confidence — the `query-db-loading-matching` rule that low-confidence candidates are left
-  unlinked for review applies unchanged.
-- Same for parcels: `business_location_parcel_links` is a separate, confidence-scored bridge
-  computed after ingest by point-in-polygon against `parcel_boundaries`. Boundaries currently
-  exist for Lee only, so for every other county this step is a no-op until its boundaries land
-  — that is expected, not a failure.
+node scripts/validate-overture-places-table.mjs \
+  --from-neon \
+  --env-file ../elephant-query-db/.env.local \
+  --county lee \
+  --release 2026-07-22.0 \
+  --parquet downloads/overture-places/lee/2026-07-22.0/publish/lee/places-table.parquet
+```
 
-## 6. Refresh — upsert by GERS id, never delete
+The publish gate requires:
 
-Overture releases monthly. A refresh **diffs**, it does not replace.
+- Parquet rows equal current Neon rows for that county/release;
+- zero duplicate GERS IDs;
+- zero null geometries;
+- `taxonomy.hierarchy` serialized as a `/`-delimited scalar;
+- the live source/licence gate passes.
 
-- Read the changelog at
-  `s3://overturemaps-us-west-2/changelog/<release>/theme=places/type=place/change_type=*/`
-  (partitioned by `theme`/`type`/`change_type`, unique index on `id`), filtered to the county
-  bbox, and touch only `added` / `removed` / `data_changed` ids. The first load for a county is
-  a full extraction; every later one is a diff.
-- Maintain `first_seen_release` and `last_seen_release`. A place absent from the current
-  release keeps its row with a stale `last_seen_release` and `is_current = false`.
-  **Absence is not closure.** Overture's `removed` change_type means only "not present in this
-  release".
-- **Closure is a field, not an inference.** Overture models it directly: `operating_status` is
-  one of `open` / temporary hiatus / `permanently_closed`, and `confidence` of exactly 0 means
-  Overture is certain the place no longer exists and is always paired with
-  `permanently_closed`. Read those. Do not derive closure from disappearance, and do not delete
-  rows for closed places — the historical record is the point.
+Publish each county's places artifact to its own resources:
 
-### GERS id stability — verified, with a caveat that matters
+```text
+Filebase bucket: elephant-oracle-open-data-<county>-places
+IPNS label:      oracle-open-data-<county>-places
+```
 
-Ids **are** GERS UUIDs and Overture's stated design goal is stability across releases,
-supported by real machinery: a GERS Registry (`first_seen`, `last_seen`, `last_changed`,
-`version`), a per-release changelog, and bridge files mapping GERS UUIDs to provider record
-ids. This was **VERIFIED** from Overture's GERS and places documentation, not assumed.
+Never share either resource with property, permit, or query-table artifacts. Fixed
+object keys and IPNS repointing can otherwise clobber or unpin another artifact family.
 
-But do not treat it as a guarantee:
+The published directory must contain:
 
-- Overture's own tutorial records that only **1,546** of the new places in the May 2025 release
-  reappeared in June with their new UUIDs, described as "a known quality issue with our source
-  datasets".
-- The places theme is documented as containing duplicates, a high junk rate and low property
-  completeness.
-- **`2026-07-22.0` — the release the scoping research used — re-matched the entire corpus with
-  a new matching pipeline, and Overture warns of "a one-time elevated level of GERS ID churn in
-  that release".** A baseline taken from `2026-07-22.0` and diffed against `2026-08` will
-  therefore show unusually high churn. That is expected; do not chase it as a bug.
+```text
+NOTICE.txt
+<county>/index.json
+<county>/places-table.parquet
+```
 
-So: GERS is the merge key, and `business_location_sources` (`dataset` + `record_id`) is the
-fallback that lets a re-identified place be re-linked through the bridge files. Carry both.
+`NOTICE.txt` is part of the IPFS DAG and must include the Overture citation and access
+date, per-provider licences, the Foursquare copyright notice, and Elephant's own change
+statement/date. `index.json` must repeat attribution in a machine-readable block and
+record release, row count, validation/PII decisions, and the artifact path.
 
-## 7. Publish
+Register the stable places-table URL in the county catalog only after public-gateway
+verification confirms `NOTICE.txt`, `index.json`, and Parquet all resolve from the
+places-family IPNS name.
 
-Follow `county-open-data-publish`, with places as its own artifact family:
+## Verified Lee result
 
-- Export `<out>/<county>/places-table.parquet` with `@dsnp/parquetjs` (the writer the query
-  table already uses). The schema is **flat and scalar-only** — that is a constraint of the
-  existing export convention, so `taxonomy.hierarchy` serialises as a `/`-delimited string with
-  the array kept in Neon for querying.
-- **Its OWN Filebase bucket and its OWN IPNS label** (`oracle-open-data-<county>-places`). The
-  publish skill's fixed-key clobber warning is the reason: the uploader writes fixed keys, so
-  sharing a bucket with the property or query-table artifacts risks unpinning them.
-- Gate before upload, mirroring `validate:query-table`: parquet row count == `business_locations`
-  rows for that county at that release, zero duplicate GERS ids, zero null geometries, and the
-  §2 licence assertion passing.
-- Register `placesTableUrl` in `catalog/published-counties.json` (see "Repo changes required").
+Reference run: Lee County, Florida, FIPS `12071`, TIGER
+`tl_2024_us_county`, Overture release `2026-07-22.0`.
 
-### Attribution is a deliverable, not a footnote
+- bbox diagnostic: **40,517** — not publishable as the county count;
+- boundary-clipped: **40,191**;
+- old scoping baseline: **40,190**; the verified clip is +1, and neither number is an
+  `expected_count`;
+- Neon `business_locations`: **40,191**, with `expected_count = NULL`;
+- source gate: PASS, `osm` absent, unknown providers empty;
+- hosted-service flag: 956 records from the five approved full paths;
+- Lee PII decision: approved 2026-08-12 to publish public business `emails` and
+  `phones` as-is;
+- dedicated Lee places Filebase/IPNS publication: verified.
 
-Places is published under **CDLA-Permissive-2.0** and **Apache-2.0** per record, with no OSM
-lineage. The Foursquare-derived subset (4,748,001 records) is Apache-2.0 and requires
-preserving `Copyright 2024 Foursquare Labs, Inc. All rights reserved.` together with a
-statement that the files were changed and the date of change. Because this publishes to public
-IPFS, that obligation ships with the artifact. Put the notice in three places:
+The loaded source spellings were `AllThePlaces`, `BrightQuery`, `DAC`, `Foursquare`,
+`meta`, `Microsoft`, `Overture`, `Overture-signals`, `PinMeTo`, and `RenderSEO`.
+`krick` is approved but was absent in Lee.
 
-1. **`NOTICE.txt` at the root of the published places bucket**, so it is inside the DAG the
-   IPNS name resolves to and travels with any copy of the data. It carries the Overture
-   citation with the accessed date, the full per-provider licence list for the places theme,
-   the Foursquare copyright line, and **Elephant's own** change statement and date — not
-   Overture's `Changed: 2026-03-18`, which describes Overture's transformation, not ours.
-2. An `attribution` block inside the places table's sibling `index.json`, so machine consumers
-   get it without a second fetch.
-3. `docs/overture-places-sources.yaml`, recording licence, attribution text, refresh cadence
-   and publication decision — the same `license:` / `publication: open-with-attribution` /
-   `bulk_terms.decision` shape `docs/rock-island-sources.yaml` established.
+## Refresh semantics
 
-> ⚠️ These terms were read from Overture's published documentation on 2026-08-12 and have
-> **not been reviewed by counsel**. Also note Overture's own warning that joining
-> CDLA-Permissive data to OpenStreetMap can make the resulting derivative database ODbL —
-> relevant the moment a published Elephant artifact combines places with an ODbL source.
+The first county run is a full extract. Later releases are upserts/diffs:
 
-## Hosted services — flag at ingest, never exclude
+- use GERS ID as the merge key and provider `dataset + record_id` as re-identification
+  evidence;
+- maintain `first_seen_release`, `last_seen_release`, and `is_current`;
+- process Overture changelog `added`, `removed`, and `data_changed` records for the
+  county;
+- never delete historical rows;
+- absence from a release is not business closure;
+- use `operating_status` for Overture's explicit closure state.
 
-Roughly 250 of Lee's 1,244 categories are not businesses occupying a location but services
-hosted inside other businesses: `atms`, `rental_kiosks` (Redbox), `propane_supplier`,
-`money_transfer_services`, `trusts`. Left unhandled, every spatial co-location analysis reads a
-Redbox as a business sharing a building.
+Re-run extraction, source gate, Neon reconciliation, export validation, attribution,
+and IPNS repointing for every release. Automated monthly discovery/execution is not
+implemented; refreshes are operator-run until that workflow lands.
 
-The decision is to **classify in ingestion and exclude in neither place**: `business_locations`
-gets a nullable `is_hosted_service boolean` plus `hosted_service_rule text` naming the rule that
-set it, driven by a committed, reviewable list at `config/hosted-service-categories.txt`
-keyed on taxonomy path and versioned with the taxonomy release.
+## Open questions and intentionally unimplemented work
 
-Excluding at ingest would violate the pipeline's ground rule that data is preserved and gaps
-logged, never dropped — and the judgement is contestable, so it must not be baked into what
-gets stored. Leaving it entirely to consumers guarantees every consumer re-derives it
-differently and gets it wrong by default. A derived, named, overridable flag is the compromise:
-it is advisory, consumers may ignore it, and the rule that produced it is auditable in git.
+- Populate `business_location_parcel_links` with a confidence-scored spatial match.
+- Onboard and boundary-validate a county other than Lee.
+- Automate monthly STAC discovery, approval/pinning, diff ingest, and publication.
+- Decide whether later counties inherit Lee's 2026-08-12 PII publication decision.
+- Add a lexicon class for business locations; do not force places into `company` or
+  property-relative `nearby_location`.
+- Decide whether downstream products need an Elephant mapping for `basic_category`;
+  the verified Lee implementation passes Overture labels through.
 
-**The list itself is not written.** The 250 categories were counted against the deprecated
-`categories` vocabulary, so the list must be rebuilt against `taxonomy.hierarchy` before it
-means anything.
-
-## Repo changes required (none are optional)
-
-- `elephant-query-db/src/schema/places.ts` + migration; register in `src/schema/index.ts`.
-- `scripts/oracle-dataset-coverage-upsert.ts` — add `overture_places` to `CoverageSource` and
-  `COVERAGE_SOURCES`, as a **global** source (county attributed from the artifact URI, like
-  sunbiz/bbb) rather than a county-keyed one.
-- `scripts/write-public-coverage-snapshot.ts` — the track list `["permits", "corporate", "bbb"]`
-  is hardcoded; add the places track.
-- `scripts/validate-publication-dry-run.ts` — the same list is hardcoded again in the
-  "honestly incomplete" loop.
-- `catalog/published-counties.json` + `catalog/README.md` + the catalog updater — add a nullable
-  `placesTableUrl`, matching how `permitQueryTableUrl` is already handled.
-- `elephant-query-db/docs/open-lexicon-gaps.md` — an Overture section, per §"Lexicon".
-
-> ⚠️ **Pre-existing inconsistency, do not propagate it.** The Neon `oracle_dataset_coverage`
-> table uses `source = 'sunbiz'` while the published snapshot writer emits `corporate` for the
-> same track. Use ONE spelling for places — `overture_places` — in both, and note the sunbiz
-> mismatch when you touch the file.
-
-## Lexicon
-
-Places do not map onto an existing lexicon class. `company` is a party (three properties:
-name, request identifier, source request) and is the conflation error in §5.
-**`nearby_location` looks like the answer and is not** — it is property-relative
-(`distance_miles`, `is_walkable`), its `location_type` is a closed 13-value lifestyle enum
-(Shopping, Dining, Nature…), and it has no identity, geometry or operating status of its own.
-It is a marketing projection _derived from_ places, not a home for them.
-
-Follow the Sunbiz precedent: land the tables in Neon now, record the gap in
-`elephant-query-db/docs/open-lexicon-gaps.md`, and raise the new class in the `lexicon` repo as
-a separate tracked PR.
-
-> ⚠️ **The Sunbiz precedent also shows how this step gets dropped.**
-> `docs/sunbiz-lexicon-transform-findings.md` states that `business_registration`,
-> `business_registration_address` and `business_registration_party` were "Added" to `../lexicon`
-> — they are **not present in `lexicon` `main`** (`src/data/lexicon.json`, checked 2026-08-12).
-> The lexicon change for the closest analogue source never landed. Track the PR and record its
-> URL, or this one will not land either.
-
-## Known gaps (do not silently fix)
-
-- The hosted-service category list does not exist yet and must be rebuilt against the new
-  taxonomy (see above).
-- `business_location_parcel_links` is unimplemented and is a no-op for every county except Lee
-  until parcel boundaries exist for them.
-- Brand (`brand.names.primary`, `brand.wikidata`) is stored but not normalised to `companies`;
-  it is the obvious future join to chains and is deliberately out of scope here.
-- Overture's provider category mappings (captured in the pipeline from the July 2026 release)
-  are not ingested — they would let a consumer trace a provider's original category, e.g.
-  BrightQuery's NAICS-based mappings, back through the Overture taxonomy.
-- Places outside every ingested county are dropped with no record that they were seen.
-
-## Open questions
-
-- Which county follows Lee? Coverage exists for Orange, Miami-Dade, Palm Beach and Santa Clara,
-  but none has a boundary-clipped count.
-- Where does the extraction run? A full-county DuckDB read is minutes, not hours, so a laptop
-  is defensible for the first county — but the load and publish inherit the
-  `EADDRNOTAVAIL`/cross-Atlantic warnings in `county-open-data-publish` and should run
-  in-region on the `open-data-publish` Fargate cluster.
-- Should Lee's 2026-08-12 PII approval extend to later county publications? Lee was approved
-  to publish as-is, including Overture business `emails` and `phones` as public
-  business-contact fields.
-- Does anything downstream need `basic_category` mapped onto Elephant's own vocabulary, or is
-  passing Overture's labels through sufficient?
-
-## Persist your work
-
-Extraction, load and export scripts are committed in `oracle-node` / `elephant-query-db` on the
-working branch. Category lists, run notes and the sources/licence record also get committed and
-PR'd to `github.com/elephant-xyz/Counties-trasform-scripts` under an `overture/` source folder
-(`gh pr create`), the same way Sunbiz and BBB artifacts are persisted. Never commit extracted
-place data; reference its S3 location.
-
-**These skills are installed from `elephant-xyz/skills`, not authored here** — every directory
-under `.agents/skills/` is untracked in `oracle-node` and pinned by `skills-lock.json`. Once
-this spec is agreed, upstream it to `elephant-xyz/skills` under `skills/overture-places-ingest/`
-and add its lock entry, or the next `skills` sync will not know it exists.
+Persist run notes and source decisions, but never extracted place data or secrets.

--- a/.agents/skills/overture-places-ingest/config/hosted-service-categories.txt
+++ b/.agents/skills/overture-places-ingest/config/hosted-service-categories.txt
@@ -1,4 +1,4 @@
-# Hosted-service categories — services offered INSIDE another business rather
+# Hosted-service categories — services offered inside another business rather
 # than a business occupying a location of its own.
 #
 # Sets `business_locations.is_hosted_service = true` and records
@@ -6,7 +6,7 @@
 # Advisory only: places are never excluded from ingestion on the strength of
 # this list, and consumers may ignore it.
 #
-# Format: one taxonomy path per line, `/`-delimited, L0 first.
+# Format: one taxonomy.hierarchy path per line, `/`-delimited, L0 first.
 # Matching is on the FULL path so a rename at one level does not silently widen.
 #
 # Rebuilt from the Lee County extract of Overture 2026-07-22.0 against
@@ -17,9 +17,9 @@
 # plural (`atms`, `rental_kiosks`, `money_transfer_services`); the July 2026
 # taxonomy uses singular leaves (`atm`, `rental_kiosk`, `money_transfer_service`).
 # Do not silently expand to ~250 hosted-looking categories — those were counted
-# against the deprecated vocab and were never enumerated as paths.
+# against the deprecated vocabulary and were never enumerated as paths.
 #
-# Not committed (reviewed, rejected for this pass):
+# Reviewed and rejected for this pass:
 # - shopping/kiosk — may occupy its own location
 # - .../vending_machine_supplier — B2B supplier, not a hosted machine
 # - .../wills_trusts_and_probate — a law firm, not a hosted trust desk

--- a/.agents/skills/overture-places-ingest/scripts/extract-county-places.sql
+++ b/.agents/skills/overture-places-ingest/scripts/extract-county-places.sql
@@ -1,16 +1,16 @@
 -- Boundary-clipped Overture places extraction for one county.
 --
--- Keep in sync with scripts/extract-county-places.sql and
--- scripts/overture-places-lib.mjs `buildExtractCopySql`.
--- Field names and the release path were read from Overture's published schema
--- on 2026-08-12. Key on taxonomy.hierarchy, not categories.primary.
+-- Keep in sync with oracle-node/scripts/overture-places-lib.mjs
+-- `buildExtractCopySql`.
+-- Field names and the release path were verified against Overture's published
+-- schema on 2026-08-12. Key on taxonomy.hierarchy, not categories.primary.
 --
 -- Usage: the Node extract script substitutes quoted literals for $RELEASE,
 -- $COUNTY_FIPS, $BOUNDARY_PATH, $PLACES_GLOB and $OUT.
 --
--- Two-stage filter is deliberate: the bbox predicate prunes parquet row groups
--- cheaply, ST_Within is the actual county test. Never report the bbox count as
--- the county count.
+-- Two-stage filtering is deliberate: the bbox predicate prunes Parquet row
+-- groups cheaply; ST_Within is the actual county test. Never report the bbox
+-- count as the county count.
 
 LOAD spatial;
 LOAD httpfs;
@@ -39,7 +39,7 @@ COPY (
     p.taxonomy.alternates               AS taxonomy_alternate,
     p.basic_category                    AS basic_category,
     -- Deprecated: removed in the September 2026 release. Retained only so the
-    -- scoping numbers stay reconcilable. Drop this column once September lands.
+    -- scoping numbers stay reconcilable. Drop once the source no longer has it.
     p.categories.primary                AS legacy_category_primary,
     p.operating_status                  AS operating_status,
     p.confidence                        AS confidence,
@@ -75,8 +75,8 @@ COPY (
     AND ST_Within(p.geometry, c.geometry)
 ) TO $OUT (FORMAT PARQUET);
 
--- Run-record counters (honest numbers; none of them is an expected_count):
---   SELECT count(*) FROM read_parquet($OUT);                          -- clip count
+-- Run-record counters (honest numbers; none is an expected_count):
+--   SELECT count(*) FROM read_parquet($OUT);                         -- clip count
 --   SELECT count(DISTINCT taxonomy_primary) FROM read_parquet($OUT);
 --   SELECT operating_status, count(*) FROM read_parquet($OUT) GROUP BY 1;
---   SELECT DISTINCT unnest(sources).dataset FROM read_parquet($OUT);  -- licence gate
+--   SELECT DISTINCT unnest(sources).dataset FROM read_parquet($OUT); -- source gate

--- a/docs/overture-places-design.md
+++ b/docs/overture-places-design.md
@@ -239,4 +239,4 @@ it has to be upstreamed with a lock entry or the next skills sync will not know 
 - Whether anything downstream later needs `basic_category` mapped onto an Elephant vocabulary.
 - Whether a places record is worth publishing for counties with no parcel boundaries, given the
   parcel link stays empty.
-- Lexicon PR for `business_location` (not opened in this pass; Sunbiz precedent dropped).
+- Lexicon proposal for `business_location`: [`elephant-xyz/lexicon#173`](https://github.com/elephant-xyz/lexicon/pull/173).

--- a/docs/overture-places-lee-pilot.md
+++ b/docs/overture-places-lee-pilot.md
@@ -256,12 +256,12 @@ Close agreement is evidence of sector coverage. It is **not** an `expected_count
 - Permanent extraction location after the Lee pilot (this run was laptop).
 - PII gate for Lee places is answered: **2026-08-12 publish as-is**, including `emails`/`phones`.
 - Whether anything downstream later needs `basic_category` mapped onto an Elephant vocabulary (pass-through for now).
-- Lexicon PR for `business_location` (not opened; Sunbiz precedent dropped).
+- Lexicon proposal for `business_location`: [`elephant-xyz/lexicon#173`](https://github.com/elephant-xyz/lexicon/pull/173).
 - Parcel-link step after ingest.
 - Whether a places record is worth publishing for counties with no parcel boundaries.
 
 ## Left unimplemented on purpose
 
 - `business_location_parcel_links` population
-- Lexicon class PR
+- Lexicon class PR merge/release ([`elephant-xyz/lexicon#173`](https://github.com/elephant-xyz/lexicon/pull/173))
 - Counties other than Lee

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "skills": {
+    "bbb-harvest": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/bbb-harvest/SKILL.md",
+      "computedHash": "d76cf1aa1f98e0d5df80e9b5e9315e7ece946a8968ce7c14bac00253b762f581"
+    },
+    "bootstrap-oracle-infra": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/bootstrap-oracle-infra/SKILL.md",
+      "computedHash": "ac9f15f45e0b4c0cb68b14524bb853a2fd9dece4339fa69ac63bfd3617fae753"
+    },
+    "county-appraisal-onboarding": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-appraisal-onboarding/SKILL.md",
+      "computedHash": "b724cb1cf41eaf65d01616b3c2cf4f6b01786a5c0f666c73b099848a6feffa80"
+    },
+    "county-discovery": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-discovery/SKILL.md",
+      "computedHash": "aac8aaa33531f01fe65d8e5e2f8a5425ed2a6cd0eea103fa4ae2ccfe6a78a0f7"
+    },
+    "county-ingest-run": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-ingest-run/SKILL.md",
+      "computedHash": "50edf4670d1ab54e20c2dc1cfe06fc6bc2672aff14df6da956076ced04fb8631"
+    },
+    "county-open-data-publish": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-open-data-publish/SKILL.md",
+      "computedHash": "327e2b8048291c7373e563812ba66e7d656b17298e9dd3539f6268c8628e867b"
+    },
+    "county-permit-adapter": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-permit-adapter/SKILL.md",
+      "computedHash": "3a2178e85a206cb70dc698499699885b93be9256bbe9ebaf2136a48f9d06e969"
+    },
+    "county-seed-data": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/county-seed-data/SKILL.md",
+      "computedHash": "2c99d94dfe8f4280292a46c55bd49edba9315584a1d045d15d3cc042867c32c6"
+    },
+    "deploy-open-data-mcp": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deploy-open-data-mcp/SKILL.md",
+      "computedHash": "cd774c699e8d4cee1beaab3c0b4af3d7c93c6f0b37fa2547dfdab00c1a9676fe"
+    },
+    "monitoring-county-ingestion": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/monitoring-county-ingestion/SKILL.md",
+      "computedHash": "417cf6da65e0d5737101bb7a66d0ec83458970cf4eeae4fe83e2fdf2e28cc392"
+    },
+    "onboard-county": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/onboard-county/SKILL.md",
+      "computedHash": "cb5b4f51847aeb82c9d01d24dac5fdd8aee8984419499e7cc56d1a664d6d9c11"
+    },
+    "overture-places-ingest": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/overture-places-ingest/SKILL.md",
+      "computedHash": "bcf942bd3a973312fcd2a542891d6a850514ee4e10de3358cee150dc1439428e"
+    },
+    "query-db-loading-matching": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/query-db-loading-matching/SKILL.md",
+      "computedHash": "e9b0b1c255050da5b72a4f88347c916089c7f0b171a9ce4cbd93dd1bbed00fe6"
+    },
+    "sunbiz-corporate-ingest": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/sunbiz-corporate-ingest/SKILL.md",
+      "computedHash": "4018cf16a1ef9b7f6e43dd356f43094598d5353f38a9eca3858e2ef0c34a9011"
+    },
+    "transform-v2-builder": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/transform-v2-builder/SKILL.md",
+      "computedHash": "e6c74e376fa8c14b6efae1f6064850880dc2d0babe6e070969d5eb0226f0d04f"
+    },
+    "validate-county-transform": {
+      "source": "elephant-xyz/skills",
+      "sourceType": "github",
+      "skillPath": "skills/validate-county-transform/SKILL.md",
+      "computedHash": "88261069ec20c1b5f3b0c4167d77b6cbf0c435e5c43807b2a3cab4b4bf6863a7"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- pin the merged `elephant-xyz/skills` Overture skill with the installer-computed hash while preserving existing lock entries
- sync the installed Overture skill to the canonical registry version
- record the durable `business_location` lexicon proposal URL in the design and Lee pilot notes

## Test plan
- [x] `npm run typecheck`
- [x] `TMPDIR=$PWD/.vitest-tmp npm run test` (611 passed)
- [x] validate the lock source/path/hash and lexicon links

## Related
- https://github.com/elephant-xyz/skills/pull/23
- https://github.com/elephant-xyz/lexicon/pull/173

Made with [Cursor](https://cursor.com)