### PR TITLE
Add safe monthly Overture places refresh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.env
+.env.*
+node_modules
+**/node_modules
+downloads
+.loader-runs
+coverage
+*.log

--- a/infra/overture-places-refresh/Dockerfile
+++ b/infra/overture-places-refresh/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json ./
+COPY prepare ./prepare
+COPY workflow ./workflow
+COPY workflow-events ./workflow-events
+COPY budget-alert ./budget-alert
+COPY scripts ./scripts
+COPY catalog ./catalog
+COPY .agents/skills/overture-places-ingest/config/hosted-service-categories.txt \
+  ./.agents/skills/overture-places-ingest/config/hosted-service-categories.txt
+
+RUN npm ci --no-audit --no-fund
+
+ENTRYPOINT ["node", "scripts/run-overture-places-refresh-stage.mjs"]

--- a/infra/overture-places-refresh/README.md
+++ b/infra/overture-places-refresh/README.md
@@ -31,7 +31,7 @@ aws stepfunctions start-execution \
 Use `releaseOverride` only for a deliberate replay:
 
 ```json
-{"releaseOverride":"2026-08-19.0"}
+{ "releaseOverride": "2026-08-19.0" }
 ```
 
 Publication requires `publishApproved:true` on a separate manual execution.

--- a/infra/overture-places-refresh/README.md
+++ b/infra/overture-places-refresh/README.md
@@ -1,0 +1,63 @@
+# Overture places monthly refresh
+
+This stack runs Lee's Overture places refresh in ECS Fargate through Step
+Functions. It reuses the existing query-db loader and Filebase publisher.
+
+The EventBridge Scheduler schedule is always created with `State: DISABLED`.
+The scheduled input also has `publishApproved:false`, so deploying this template
+cannot silently publish or start monthly spend.
+
+## Manual validation
+
+Start with a read-only STAC/Neon plan:
+
+```sh
+aws stepfunctions start-execution \
+  --state-machine-arn "$STATE_MACHINE_ARN" \
+  --name "lee-plan-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --input '{"county":"lee","countyFips":"12071","boundarySource":"tiger/tl_2024_us_county","dryRun":true,"publishApproved":false,"costCeilingUsd":10}'
+```
+
+If the plan identifies a newer release, run extraction, validation, load, and
+full-current export without changing Filebase/IPNS:
+
+```sh
+aws stepfunctions start-execution \
+  --state-machine-arn "$STATE_MACHINE_ARN" \
+  --name "lee-validate-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --input '{"county":"lee","countyFips":"12071","boundarySource":"tiger/tl_2024_us_county","dryRun":false,"publishApproved":false,"costCeilingUsd":10}'
+```
+
+Use `releaseOverride` only for a deliberate replay:
+
+```json
+{"releaseOverride":"2026-08-19.0"}
+```
+
+Publication requires `publishApproved:true` on a separate manual execution.
+Do not use that value until the code is merged and the validation-only run has
+succeeded.
+
+## Enable the monthly schedule after approval
+
+Enabling requires an explicit input change as well as changing Scheduler state.
+First save the deployed target, then change only its input:
+
+```sh
+aws scheduler get-schedule \
+  --name oracle-overture-places-refresh-monthly \
+  --query Target > /tmp/overture-places-target.json
+
+jq '.Input = "{\"county\":\"lee\",\"countyFips\":\"12071\",\"boundarySource\":\"tiger/tl_2024_us_county\",\"dryRun\":false,\"publishApproved\":true,\"costCeilingUsd\":10}"' \
+  /tmp/overture-places-target.json > /tmp/overture-places-target-approved.json
+
+aws scheduler update-schedule \
+  --name oracle-overture-places-refresh-monthly \
+  --schedule-expression 'cron(0 8 2 * ? *)' \
+  --flexible-time-window '{"Mode":"OFF"}' \
+  --state ENABLED \
+  --target file:///tmp/overture-places-target-approved.json
+```
+
+This enable action is intentionally outside deployment. It requires separate
+operator approval after the manual workflow has passed.

--- a/infra/overture-places-refresh/template.yaml
+++ b/infra/overture-places-refresh/template.yaml
@@ -41,7 +41,8 @@ Parameters:
     Description: Optional existing SNS topic for failed execution alarms
 
 Conditions:
-  HasFailureNotificationTopic: !Not [!Equals [!Ref FailureNotificationTopicArn, ""]]
+  HasFailureNotificationTopic:
+    !Not [!Equals [!Ref FailureNotificationTopicArn, ""]]
 
 Resources:
   RefreshLogGroup:

--- a/infra/overture-places-refresh/template.yaml
+++ b/infra/overture-places-refresh/template.yaml
@@ -1,0 +1,917 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Manual-first monthly Overture places refresh for Lee County
+
+Parameters:
+  ServiceName:
+    Type: String
+    Default: oracle-overture-places-refresh
+  OracleImageUri:
+    Type: String
+    Description: Immutable oracle-node refresh image URI
+  QueryDbImageUri:
+    Type: String
+    Description: Immutable elephant-query-db image URI with places load/publish support
+  ClusterArn:
+    Type: String
+    Description: Existing ECS cluster ARN
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+  AssignPublicIp:
+    Type: String
+    Default: ENABLED
+    AllowedValues: [ENABLED, DISABLED]
+  WorkBucketName:
+    Type: String
+    Description: Existing private AWS S3 bucket for run artifacts
+  DatabaseSecretArn:
+    Type: String
+    Description: Secrets Manager ARN whose value is the direct Neon URL
+  FilebaseSecretArn:
+    Type: String
+    Description: Secrets Manager ARN with S3_ENDPOINT, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, and FILEBASE_API_TOKEN
+  ScheduleExpression:
+    Type: String
+    Default: cron(0 8 2 * ? *)
+    Description: Monthly UTC schedule; the schedule resource is always deployed disabled
+  FailureNotificationTopicArn:
+    Type: String
+    Default: ""
+    Description: Optional existing SNS topic for failed execution alarms
+
+Conditions:
+  HasFailureNotificationTopic: !Not [!Equals [!Ref FailureNotificationTopicArn, ""]]
+
+Resources:
+  RefreshLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${ServiceName}"
+      RetentionInDays: 30
+
+  RefreshLockTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: lock_key
+          AttributeType: S
+      KeySchema:
+        - AttributeName: lock_key
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: true
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PullLogAndReadSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "${RefreshLogGroup.Arn}:*"
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref DatabaseSecretArn
+                  - !Ref FilebaseSecretArn
+
+  RefreshTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: RefreshArtifactsAndCallbacks
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub "arn:${AWS::Partition}:s3:::${WorkBucketName}"
+                Condition:
+                  StringLike:
+                    s3:prefix:
+                      - overture-places-refresh/*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "arn:${AWS::Partition}:s3:::${WorkBucketName}/overture-places-refresh/*"
+              - Effect: Allow
+                Action:
+                  - states:SendTaskSuccess
+                  - states:SendTaskFailure
+                  - states:SendTaskHeartbeat
+                Resource: "*"
+
+  OracleTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${ServiceName}-oracle"
+      Cpu: "4096"
+      Memory: "16384"
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt RefreshTaskRole.Arn
+      ContainerDefinitions:
+        - Name: oracle-refresh
+          Image: !Ref OracleImageUri
+          Essential: true
+          Secrets:
+            - Name: DATABASE_URL_UNPOOLED
+              ValueFrom: !Ref DatabaseSecretArn
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref RefreshLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: oracle
+
+  LoadTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${ServiceName}-load"
+      Cpu: "4096"
+      Memory: "16384"
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt RefreshTaskRole.Arn
+      ContainerDefinitions:
+        - Name: places-load
+          Image: !Ref QueryDbImageUri
+          Essential: true
+          EntryPoint: [sh, scripts/reload-appraisal-entrypoint.sh]
+          Secrets:
+            - Name: DATABASE_URL
+              ValueFrom: !Ref DatabaseSecretArn
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref RefreshLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: load
+
+  PublishTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${ServiceName}-publish"
+      Cpu: "1024"
+      Memory: "2048"
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt RefreshTaskRole.Arn
+      ContainerDefinitions:
+        - Name: places-publish
+          Image: !Ref QueryDbImageUri
+          Essential: true
+          EntryPoint:
+            - node_modules/.bin/tsx
+            - scripts/run-places-refresh-publish.ts
+          Secrets:
+            - Name: S3_ENDPOINT
+              ValueFrom: !Sub "${FilebaseSecretArn}:S3_ENDPOINT::"
+            - Name: S3_ACCESS_KEY_ID
+              ValueFrom: !Sub "${FilebaseSecretArn}:S3_ACCESS_KEY_ID::"
+            - Name: S3_SECRET_ACCESS_KEY
+              ValueFrom: !Sub "${FilebaseSecretArn}:S3_SECRET_ACCESS_KEY::"
+            - Name: FILEBASE_API_TOKEN
+              ValueFrom: !Sub "${FilebaseSecretArn}:FILEBASE_API_TOKEN::"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref RefreshLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: publish
+
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: RunRefresh
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ecs:RunTask
+                Resource:
+                  - !Ref OracleTaskDefinition
+                  - !Ref LoadTaskDefinition
+                  - !Ref PublishTaskDefinition
+              - Effect: Allow
+                Action:
+                  - ecs:StopTask
+                  - ecs:DescribeTasks
+                Resource: "*"
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource:
+                  - !GetAtt TaskExecutionRole.Arn
+                  - !GetAtt RefreshTaskRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: ecs-tasks.amazonaws.com
+              - Effect: Allow
+                Action:
+                  - events:PutTargets
+                  - events:PutRule
+                  - events:DescribeRule
+                Resource: !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForECSTaskRule"
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:DeleteItem
+                Resource: !GetAtt RefreshLockTable.Arn
+
+  RefreshStateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Ref ServiceName
+      RoleArn: !GetAtt StateMachineRole.Arn
+      DefinitionSubstitutions:
+        ClusterArn: !Ref ClusterArn
+        OracleTaskDefinition: !Ref OracleTaskDefinition
+        LoadTaskDefinition: !Ref LoadTaskDefinition
+        PublishTaskDefinition: !Ref PublishTaskDefinition
+        Subnet0: !Select [0, !Ref SubnetIds]
+        SecurityGroupId: !Ref SecurityGroupId
+        AssignPublicIp: !Ref AssignPublicIp
+        WorkBucketName: !Ref WorkBucketName
+        LockTableName: !Ref RefreshLockTable
+      DefinitionString: |
+        {
+          "Comment": "Manual-first, idempotent Overture places refresh. Public publish requires explicit input approval.",
+          "StartAt": "Plan",
+          "States": {
+            "Plan": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 1800,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "plan"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      {
+                        "Name": "WORKFLOW_INPUT",
+                        "Value.$": "States.JsonToString(States.JsonMerge($, States.StringToJson('{\"workBucket\":\"${WorkBucketName}\"}'), false))"
+                      },
+                      { "Name": "REFRESH_STAGE", "Value": "plan" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["ECS.AmazonECSException", "ECS.ECSException", "States.Timeout"],
+                "IntervalSeconds": 20,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "Next": "PlanDecision"
+            },
+            "PlanDecision": {
+              "Type": "Choice",
+              "Choices": [
+                { "Variable": "$.action", "StringEquals": "noop", "Next": "NoOp" },
+                { "Variable": "$.dryRun", "BooleanEquals": true, "Next": "DryRunComplete" },
+                { "Variable": "$.withinCostCeiling", "BooleanEquals": false, "Next": "CostGateStopped" }
+              ],
+              "Default": "AcquireCountyLock"
+            },
+            "NoOp": { "Type": "Succeed" },
+            "DryRunComplete": { "Type": "Succeed" },
+            "CostGateStopped": {
+              "Type": "Fail",
+              "Error": "CostGateError",
+              "Cause": "Estimated refresh cost exceeds maxEstimatedCostUsd"
+            },
+            "AcquireCountyLock": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
+              "Parameters": {
+                "TableName": "${LockTableName}",
+                "Item": {
+                  "lock_key": { "S.$": "$.county" },
+                  "execution_id": { "S.$": "$$.Execution.Id" },
+                  "release": { "S.$": "$.release" },
+                  "idempotency_key": { "S.$": "$.idempotencyKey" },
+                  "expires_at": { "N.$": "States.Format('{}', $.lockExpiresAtEpoch)" }
+                },
+                "ConditionExpression": "attribute_not_exists(lock_key) OR expires_at < :now",
+                "ExpressionAttributeValues": {
+                  ":now": { "N.$": "States.Format('{}', $.lockNowEpoch)" }
+                }
+              },
+              "ResultPath": null,
+              "Catch": [
+                {
+                  "ErrorEquals": ["DynamoDb.ConditionalCheckFailedException"],
+                  "ResultPath": "$.failure",
+                  "Next": "AlreadyRunning"
+                },
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "ResultPath": "$.failure",
+                  "Next": "InfrastructureFailure"
+                }
+              ],
+              "Next": "Extract"
+            },
+            "AlreadyRunning": {
+              "Type": "Fail",
+              "Error": "CountyRefreshAlreadyRunning",
+              "Cause": "Another refresh holds the county lock"
+            },
+            "InfrastructureFailure": {
+              "Type": "Fail",
+              "Error": "RefreshInfrastructureFailure",
+              "Cause": "Could not acquire the county refresh lock"
+            },
+            "Extract": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 7200,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "extract"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      { "Name": "WORKFLOW_INPUT", "Value.$": "States.JsonToString($)" },
+                      { "Name": "REFRESH_STAGE", "Value": "extract" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException", "States.Timeout"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.extraction",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "ValidateIncoming"
+            },
+            "ValidateIncoming": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 900,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "validate"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      { "Name": "WORKFLOW_INPUT", "Value.$": "States.JsonToString($)" },
+                      { "Name": "REFRESH_STAGE", "Value": "validate" }
+                    ]
+                  }]
+                }
+              },
+              "ResultPath": "$.validation",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "LoadShape"
+            },
+            "LoadShape": {
+              "Type": "Choice",
+              "Choices": [{
+                "Variable": "$.action",
+                "StringEquals": "incremental",
+                "Next": "LoadIncremental"
+              }],
+              "Default": "LoadFull"
+            },
+            "LoadIncremental": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.sync",
+              "TimeoutSeconds": 7200,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${LoadTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "places-load",
+                    "Environment": [
+                      { "Name": "TRACKS", "Value": "places" },
+                      { "Name": "STEP", "Value": "load" },
+                      { "Name": "SKIP_CLEAR", "Value": "1" },
+                      { "Name": "APPRAISAL_PREFIX", "Value": "unused" },
+                      { "Name": "APPRAISAL_BUCKET", "Value.$": "$.workBucket" },
+                      { "Name": "PLACES_PREFIX", "Value.$": "$.runPrefix" },
+                      { "Name": "PLACES_RELEASE", "Value.$": "$.release" },
+                      {
+                        "Name": "PLACES_DEACTIVATION_MANIFEST",
+                        "Value.$": "States.Format('s3://{}/{}/manifest/deactivation.json', $.workBucket, $.runPrefix)"
+                      },
+                      { "Name": "JURISDICTION_KEY", "Value.$": "$.county" },
+                      { "Name": "BATCH_SIZE", "Value": "0" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": null,
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "ExportFullCurrent"
+            },
+            "LoadFull": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.sync",
+              "TimeoutSeconds": 7200,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${LoadTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "places-load",
+                    "Environment": [
+                      { "Name": "TRACKS", "Value": "places" },
+                      { "Name": "STEP", "Value": "load" },
+                      { "Name": "SKIP_CLEAR", "Value": "1" },
+                      { "Name": "APPRAISAL_PREFIX", "Value": "unused" },
+                      { "Name": "APPRAISAL_BUCKET", "Value.$": "$.workBucket" },
+                      { "Name": "PLACES_PREFIX", "Value.$": "$.runPrefix" },
+                      { "Name": "PLACES_RELEASE", "Value.$": "$.release" },
+                      { "Name": "JURISDICTION_KEY", "Value.$": "$.county" },
+                      { "Name": "BATCH_SIZE", "Value": "0" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": null,
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "ExportFullCurrent"
+            },
+            "ExportFullCurrent": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 3600,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "export"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      { "Name": "WORKFLOW_INPUT", "Value.$": "States.JsonToString($)" },
+                      { "Name": "REFRESH_STAGE", "Value": "export" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.export",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "PublicationApproved"
+            },
+            "PublicationApproved": {
+              "Type": "Choice",
+              "Choices": [{
+                "Variable": "$.publishApproved",
+                "BooleanEquals": true,
+                "Next": "Publish"
+              }],
+              "Default": "ReleaseValidationOnlyLock"
+            },
+            "ReleaseValidationOnlyLock": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:deleteItem",
+              "Parameters": {
+                "TableName": "${LockTableName}",
+                "Key": { "lock_key": { "S.$": "$.county" } },
+                "ConditionExpression": "execution_id = :execution",
+                "ExpressionAttributeValues": {
+                  ":execution": { "S.$": "$$.Execution.Id" }
+                }
+              },
+              "ResultPath": null,
+              "Next": "ValidationOnlyComplete"
+            },
+            "ValidationOnlyComplete": { "Type": "Succeed" },
+            "Publish": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 1800,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${PublishTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "places-publish",
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      {
+                        "Name": "WORKFLOW_INPUT",
+                        "Value.$": "States.JsonToString(States.JsonMerge(States.StringToJson(States.Format('{\"county\":\"{}\"}', $.county)), States.StringToJson(States.Format('{\"artifactS3Uri\":\"{}\"}', $.export.artifactS3Uri)), false))"
+                      }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException", "States.Timeout"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 2,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.publishResult",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "VerifyPublishedPointer"
+            },
+            "VerifyPublishedPointer": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 1800,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "verify"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      { "Name": "WORKFLOW_INPUT", "Value.$": "States.JsonToString($)" },
+                      { "Name": "REFRESH_STAGE", "Value": "verify" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 4,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.publishResult",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "RollbackDecision"
+              }],
+              "Next": "Finalize"
+            },
+            "Finalize": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 900,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${OracleTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "oracle-refresh",
+                    "Command": ["--stage", "finalize"],
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      { "Name": "WORKFLOW_INPUT", "Value.$": "States.JsonToString($)" },
+                      { "Name": "REFRESH_STAGE", "Value": "finalize" }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 20,
+                "MaxAttempts": 3,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.final",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.failure",
+                "Next": "RollbackDecision"
+              }],
+              "Next": "ReleaseSuccessLock"
+            },
+            "RollbackDecision": {
+              "Type": "Choice",
+              "Choices": [{
+                "Variable": "$.publishResult.previousCid",
+                "IsString": true,
+                "Next": "RollbackPublishedPointer"
+              }],
+              "Default": "ReleaseFailureLock"
+            },
+            "RollbackPublishedPointer": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
+              "TimeoutSeconds": 900,
+              "Parameters": {
+                "Cluster": "${ClusterArn}",
+                "TaskDefinition": "${PublishTaskDefinition}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ["${Subnet0}"],
+                    "SecurityGroups": ["${SecurityGroupId}"],
+                    "AssignPublicIp": "${AssignPublicIp}"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [{
+                    "Name": "places-publish",
+                    "Environment": [
+                      { "Name": "TASK_TOKEN", "Value.$": "$$.Task.Token" },
+                      {
+                        "Name": "WORKFLOW_INPUT",
+                        "Value.$": "States.JsonToString(States.StringToJson(States.Format('{\"mode\":\"rollback\",\"county\":\"{}\",\"previousCid\":\"{}\"}', $.county, $.publishResult.previousCid)))"
+                      }
+                    ]
+                  }]
+                }
+              },
+              "Retry": [{
+                "ErrorEquals": ["Error", "ECS.AmazonECSException", "ECS.ECSException"],
+                "IntervalSeconds": 20,
+                "MaxAttempts": 3,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }],
+              "ResultPath": "$.rollback",
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.rollbackFailure",
+                "Next": "ReleaseFailureLock"
+              }],
+              "Next": "ReleaseFailureLock"
+            },
+            "ReleaseSuccessLock": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:deleteItem",
+              "Parameters": {
+                "TableName": "${LockTableName}",
+                "Key": { "lock_key": { "S.$": "$.county" } },
+                "ConditionExpression": "execution_id = :execution",
+                "ExpressionAttributeValues": {
+                  ":execution": { "S.$": "$$.Execution.Id" }
+                }
+              },
+              "ResultPath": null,
+              "Next": "Succeeded"
+            },
+            "Succeeded": { "Type": "Succeed" },
+            "ReleaseFailureLock": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:deleteItem",
+              "Parameters": {
+                "TableName": "${LockTableName}",
+                "Key": { "lock_key": { "S.$": "$.county" } },
+                "ConditionExpression": "execution_id = :execution",
+                "ExpressionAttributeValues": {
+                  ":execution": { "S.$": "$$.Execution.Id" }
+                }
+              },
+              "ResultPath": null,
+              "Catch": [{
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": null,
+                "Next": "Failed"
+              }],
+              "Next": "Failed"
+            },
+            "Failed": {
+              "Type": "Fail",
+              "Error": "OverturePlacesRefreshFailed",
+              "Cause": "A refresh stage failed; public finalization did not run"
+            }
+          }
+        }
+
+  SchedulerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StartRefresh
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource: !Ref RefreshStateMachine
+
+  MonthlySchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Name: !Sub "${ServiceName}-monthly"
+      Description: Disabled until an explicit post-validation approval enables Lee publication
+      State: DISABLED
+      ScheduleExpression: !Ref ScheduleExpression
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      Target:
+        Arn: !Ref RefreshStateMachine
+        RoleArn: !GetAtt SchedulerRole.Arn
+        Input: >-
+          {"county":"lee","countyFips":"12071","boundarySource":"tiger/tl_2024_us_county","dryRun":false,"publishApproved":false,"costCeilingUsd":10}
+
+  RefreshFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Overture places refresh state machine execution failed
+      Namespace: AWS/States
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Ref RefreshStateMachine
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasFailureNotificationTopic
+        - [!Ref FailureNotificationTopicArn]
+        - !Ref AWS::NoValue
+
+Outputs:
+  StateMachineArn:
+    Value: !Ref RefreshStateMachine
+  ScheduleName:
+    Value: !Ref MonthlySchedule
+  ScheduleState:
+    Value: DISABLED
+  LockTableName:
+    Value: !Ref RefreshLockTable

--- a/scripts/export-overture-places-table.mjs
+++ b/scripts/export-overture-places-table.mjs
@@ -474,9 +474,8 @@ export async function loadPlacesFromNeon(options) {
        FROM business_locations
        WHERE source_system = 'overture_places'
          AND county_key = $1
-         AND last_seen_release = $2
          AND is_current = true`,
-      [options.county, options.release],
+      [options.county],
     );
     const businessLocationRowCount = Number(countResult.rows[0]?.n ?? 0);
     const rowsResult = await client.query(
@@ -509,10 +508,9 @@ export async function loadPlacesFromNeon(options) {
        FROM business_locations
        WHERE source_system = 'overture_places'
          AND county_key = $1
-         AND last_seen_release = $2
          AND is_current = true
        ORDER BY gers_id`,
-      [options.county, options.release],
+      [options.county],
     );
     const datasetsResult = await client.query(
       `SELECT DISTINCT s.dataset
@@ -520,10 +518,9 @@ export async function loadPlacesFromNeon(options) {
        JOIN business_locations l ON l.business_location_id = s.business_location_id
        WHERE l.source_system = 'overture_places'
          AND l.county_key = $1
-         AND l.last_seen_release = $2
          AND l.is_current = true
        ORDER BY 1`,
-      [options.county, options.release],
+      [options.county],
     );
     const extractionResult = await client.query(
       `SELECT source_payload
@@ -668,7 +665,8 @@ function accessedDateFromExtraction(payload) {
     typeof payload === "object" &&
     !Array.isArray(payload)
   ) {
-    const finishedAt = payload.finishedAt;
+    const finishedAt =
+      /** @type {Record<string, unknown>} */ (payload).finishedAt;
     if (typeof finishedAt === "string" && finishedAt.length >= 10) {
       return finishedAt.slice(0, 10);
     }

--- a/scripts/export-overture-places-table.mjs
+++ b/scripts/export-overture-places-table.mjs
@@ -665,8 +665,8 @@ function accessedDateFromExtraction(payload) {
     typeof payload === "object" &&
     !Array.isArray(payload)
   ) {
-    const finishedAt =
-      /** @type {Record<string, unknown>} */ (payload).finishedAt;
+    const finishedAt = /** @type {Record<string, unknown>} */ (payload)
+      .finishedAt;
     if (typeof finishedAt === "string" && finishedAt.length >= 10) {
       return finishedAt.slice(0, 10);
     }

--- a/scripts/extract-overture-places-changelog.mjs
+++ b/scripts/extract-overture-places-changelog.mjs
@@ -1,0 +1,627 @@
+#!/usr/bin/env node
+
+/**
+ * Incremental Overture places extraction for one county and pinned release.
+ *
+ * The changelog is the change selector. Current geometries are first pruned by
+ * the county bbox and then clipped with `ST_Within`. Existing Neon GERS IDs are
+ * joined to removed/data_changed partitions so moves out and removals are
+ * deactivated even when their current geometry is no longer in Lee.
+ */
+
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { createRequire } from "node:module";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import * as path from "node:path";
+
+import {
+  assertApprovedPlaceDatasets,
+  collectDatasetsFromSources,
+  confidenceDistribution,
+  countByOperatingStatus,
+  duckdbStringLiteral,
+  hostedServiceRuleId,
+  matchHostedService,
+  overturePlacesParquetGlob,
+  parseHostedServiceCategoryList,
+  parseTigerBoundarySource,
+  taxonomyHierarchyToPath,
+  taxonomyPathToHierarchy,
+} from "./overture-places-lib.mjs";
+import {
+  assertOvertureChangelogSchema,
+  buildTaxonomyDriftReport,
+  classifyPlaceChanges,
+  overturePlacesChangelogGlobs,
+} from "./overture-places-refresh-lib.mjs";
+import { ensureTigerShapefile, mapPlaceRow } from "./extract-overture-places.mjs";
+
+const require = createRequire(import.meta.url);
+const duckdb = require("duckdb");
+
+/**
+ * @typedef {Record<string, unknown>} JsonObject
+ */
+
+/**
+ * @typedef {object} IncrementalExtractOptions
+ * @property {string} county County key.
+ * @property {string} countyFips County FIPS.
+ * @property {string} countyName Human county name.
+ * @property {string} release Current pinned release.
+ * @property {string} previousRelease Previous successful release.
+ * @property {string} boundarySource TIGER boundary token.
+ * @property {string} cacheDir Local DuckDB/TIGER cache root.
+ * @property {string} hostedServiceListPath Committed hosted-service path list.
+ * @property {string} workDir Local run directory.
+ * @property {string} outputBucket Internal AWS S3 bucket.
+ * @property {string} outputPrefix Run-scoped output prefix.
+ * @property {string} databaseUrl Direct or pooled Neon URL for read-only ID selection.
+ * @property {number} partRecordLimit Maximum JSONL rows per part.
+ */
+
+/**
+ * @typedef {object} DuckdbConnection
+ * @property {(sql: string) => Promise<JsonObject[]>} all Query rows.
+ * @property {(sql: string) => Promise<void>} exec Execute statements.
+ * @property {() => Promise<void>} close Close database.
+ */
+
+/**
+ * Run a changelog extraction and stage the run-scoped artifacts to AWS S3.
+ *
+ * @param {IncrementalExtractOptions} options Validated extraction options.
+ * @returns {Promise<JsonObject>} Summary consumed by validation and the loader.
+ */
+export async function runIncrementalPlacesExtract(options) {
+  const startedAt = new Date();
+  const runRoot = path.resolve(options.workDir);
+  await rm(runRoot, { recursive: true, force: true });
+  await mkdir(runRoot, { recursive: true });
+  const tiger = parseTigerBoundarySource(options.boundarySource);
+  const shapefilePath = await ensureTigerShapefile(options.cacheDir, tiger);
+  const hostedServicePaths = parseHostedServiceCategoryList(
+    await readFile(options.hostedServiceListPath, "utf8"),
+  );
+  const existingCurrentIds = await readCurrentCountyGersIds(
+    options.databaseUrl,
+    options.county,
+  );
+  const existingPath = path.join(runRoot, "existing-current-ids.json");
+  await writeFile(
+    existingPath,
+    `${existingCurrentIds.map((gersId) => JSON.stringify({ gers_id: gersId })).join("\n")}\n`,
+    "utf8",
+  );
+
+  const db = await openDuckdb();
+  try {
+    const duckdbTempDir = path.join(runRoot, "duckdb-tmp");
+    await mkdir(duckdbTempDir, { recursive: true });
+    await db.exec("INSTALL spatial; INSTALL httpfs; LOAD spatial; LOAD httpfs;");
+    await db.exec("SET s3_region = 'us-west-2';");
+    await db.exec(
+      `SET temp_directory = ${duckdbStringLiteral(duckdbTempDir)};`,
+    );
+    await createRefreshViews({
+      db,
+      options,
+      shapefilePath,
+      existingPath,
+    });
+
+    const changelogSchemaRows = await db.all("DESCRIBE SELECT * FROM changes");
+    const changelogColumns = changelogSchemaRows.flatMap((row) =>
+      typeof row.column_name === "string" ? [row.column_name] : [],
+    );
+    const changelogSchema = assertOvertureChangelogSchema(changelogColumns);
+    const currentCountyIds = (await db.all("SELECT id FROM current_county")).map(
+      (row) => String(row.id),
+    );
+    const changelogRows = (
+      await db.all(
+        `SELECT DISTINCT c.id, c.change_type
+         FROM changes c
+         JOIN (
+           SELECT id FROM current_county
+           UNION
+           SELECT gers_id AS id FROM existing_ids
+         ) relevant ON relevant.id = c.id
+         WHERE c.change_type IN ('added', 'data_changed', 'removed')`,
+      )
+    ).map((row) => ({
+      id: String(row.id),
+      changeType: String(row.change_type),
+    }));
+    const classified = classifyPlaceChanges({
+      existingCurrentIds,
+      currentCountyIds,
+      changelogRows,
+    });
+    const changedRows = await readChangedCurrentRows(db);
+    const changedById = new Map(
+      changelogRows.map((row) => [row.id, row.changeType]),
+    );
+    const mappedRows = changedRows.map((row) => {
+      const mapped = mapIncrementalPlaceRow({
+        row,
+        options,
+        hostedServicePaths,
+      });
+      mapped.change_type = changedById.get(String(row.gers_id)) ?? "unknown";
+      return mapped;
+    });
+    const parts = await writeJsonlParts({
+      records: mappedRows,
+      runRoot,
+      partRecordLimit: options.partRecordLimit,
+    });
+    const deactivationRows = classified.deactivateIds.map((gersId) => {
+      const changeType = changedById.get(gersId);
+      return {
+        gersId,
+        changeType,
+        reason:
+          changeType === "removed"
+            ? "removed_from_overture_release"
+            : "geometry_outside_county",
+      };
+    });
+    await writeJson(path.join(runRoot, "manifest/deactivations.json"), {
+      schemaVersion: "oracle-node.overture-place-deactivations.v1",
+      county: options.county,
+      countyFips: options.countyFips,
+      release: options.release,
+      previousRelease: options.previousRelease,
+      records: deactivationRows,
+    });
+
+    const taxonomyPaths = (
+      await db.all(
+        `SELECT DISTINCT taxonomy.hierarchy AS hierarchy
+         FROM current_county
+         WHERE taxonomy.hierarchy IS NOT NULL`,
+      )
+    ).flatMap((row) => {
+      const taxonomyPath = taxonomyHierarchyToPath(row.hierarchy);
+      return taxonomyPath === null ? [] : [taxonomyPath];
+    });
+    const taxonomyDrift = buildTaxonomyDriftReport({
+      release: options.release,
+      previousRelease: options.previousRelease,
+      currentPaths: taxonomyPaths,
+      configuredPaths: hostedServicePaths,
+    });
+    await writeJson(
+      path.join(runRoot, "manifest/taxonomy-drift.json"),
+      taxonomyDrift,
+    );
+    await writeJson(
+      path.join(runRoot, "manifest/changelog-schema.json"),
+      changelogSchema,
+    );
+
+    const counters = await readFullCountyCounters(
+      db,
+      options.release,
+      hostedServicePaths,
+    );
+    const incomingDatasets = uniqueSorted(
+      changedRows.flatMap((row) =>
+        collectDatasetsFromSources(row.sources),
+      ),
+    );
+    const licenceGate = assertApprovedPlaceDatasets(incomingDatasets);
+    const finishedAt = new Date();
+    const summary = {
+      schemaVersion: "oracle-node.overture-places-extract.v2",
+      mode: "incremental",
+      county: options.county,
+      countyFips: options.countyFips,
+      overtureRelease: options.release,
+      previousRelease: options.previousRelease,
+      boundarySource: options.boundarySource,
+      tigerYear: tiger.year,
+      bboxCount: counters.bboxCount,
+      clipCount: counters.clipCount,
+      activeChangeCount: mappedRows.length,
+      deactivationCount: deactivationRows.length,
+      changeCounts: classified.counts,
+      moveCounts: {
+        movedIn: classified.movedInIds.length,
+        movedOut: classified.movedOutIds.length,
+      },
+      distinctTaxonomyPrimary: counters.distinctTaxonomyPrimary,
+      distinctTaxonomyHierarchyPaths: taxonomyPaths.length,
+      distinctSourceDatasets: incomingDatasets,
+      licenceGate,
+      taxonomyDrift,
+      operatingStatusCounts: counters.operatingStatusCounts,
+      confidenceDistribution: counters.confidenceDistribution,
+      hostedServiceFlagCount: counters.hostedServiceFlagCount,
+      jsonl: {
+        partCount: parts.length,
+        recordCount: mappedRows.length,
+        parts,
+      },
+      deactivations: {
+        recordCount: deactivationRows.length,
+        path: "manifest/deactivations.json",
+      },
+      extractionLocation: "ecs-fargate",
+      expectedCount: null,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      runStatus: "validated_pending",
+    };
+    await writeJson(path.join(runRoot, "manifest/summary.json"), summary);
+    await uploadRunTree({
+      localRoot: runRoot,
+      bucket: options.outputBucket,
+      prefix: options.outputPrefix,
+    });
+    return {
+      ...summary,
+      artifactS3Uri: `s3://${options.outputBucket}/${options.outputPrefix.replace(/\/+$/, "")}/`,
+    };
+  } finally {
+    await db.close();
+  }
+}
+
+/**
+ * Build lazy DuckDB views over the current release and the three processed
+ * changelog partitions.
+ *
+ * @param {object} params View inputs.
+ * @param {DuckdbConnection} params.db DuckDB connection.
+ * @param {IncrementalExtractOptions} params.options Extraction options.
+ * @param {string} params.shapefilePath Local TIGER shapefile.
+ * @param {string} params.existingPath Local JSONL containing current Neon IDs.
+ * @returns {Promise<void>}
+ */
+async function createRefreshViews(params) {
+  const changelogList = overturePlacesChangelogGlobs(params.options.release)
+    .map(duckdbStringLiteral)
+    .join(", ");
+  await params.db.exec(`
+CREATE OR REPLACE TEMP TABLE county_boundary AS
+SELECT geom AS geometry
+FROM ST_Read(${duckdbStringLiteral(params.shapefilePath)})
+WHERE GEOID = ${duckdbStringLiteral(params.options.countyFips)};
+
+CREATE OR REPLACE TEMP TABLE county_bbox AS
+SELECT
+  ST_XMin(ST_Extent(geometry)) AS xmin,
+  ST_XMax(ST_Extent(geometry)) AS xmax,
+  ST_YMin(ST_Extent(geometry)) AS ymin,
+  ST_YMax(ST_Extent(geometry)) AS ymax
+FROM county_boundary;
+
+CREATE OR REPLACE TEMP TABLE existing_ids AS
+SELECT gers_id
+FROM read_json_auto(${duckdbStringLiteral(params.existingPath)}, format = 'newline_delimited');
+
+CREATE OR REPLACE TEMP VIEW changes AS
+SELECT id, bbox, change_type, theme, type
+FROM read_parquet([${changelogList}], hive_partitioning = 1);
+
+CREATE OR REPLACE TEMP VIEW current_county AS
+SELECT p.*
+FROM read_parquet(
+       ${duckdbStringLiteral(overturePlacesParquetGlob(params.options.release))},
+       hive_partitioning = 1
+     ) p,
+     county_bbox b,
+     county_boundary c
+WHERE p.bbox.xmin >= b.xmin
+  AND p.bbox.xmax <= b.xmax
+  AND p.bbox.ymin >= b.ymin
+  AND p.bbox.ymax <= b.ymax
+  AND ST_Within(p.geometry, c.geometry);
+`);
+}
+
+/**
+ * Read full current Overture records only for selected changed IDs.
+ *
+ * @param {DuckdbConnection} db DuckDB connection.
+ * @returns {Promise<JsonObject[]>} Aliased place rows compatible with the initial mapper.
+ */
+async function readChangedCurrentRows(db) {
+  return db.all(`
+SELECT
+  p.id                                AS gers_id,
+  p.version                           AS overture_version,
+  p.names.primary                     AS name_primary,
+  p.taxonomy.primary                  AS taxonomy_primary,
+  p.taxonomy.hierarchy                AS taxonomy_hierarchy,
+  p.taxonomy.alternates               AS taxonomy_alternate,
+  p.basic_category                    AS basic_category,
+  p.categories.primary                AS legacy_category_primary,
+  p.operating_status                  AS operating_status,
+  p.confidence                        AS confidence,
+  p.websites                          AS websites,
+  p.socials                           AS socials,
+  p.emails                            AS emails,
+  p.phones                            AS phones,
+  p.brand.names.primary               AS brand_name,
+  p.brand.wikidata                    AS brand_wikidata,
+  p.addresses[1].freeform             AS address_freeform,
+  p.addresses[1].locality             AS address_locality,
+  p.addresses[1].postcode             AS address_postcode,
+  p.addresses[1].region               AS address_region,
+  p.addresses[1].country              AS address_country,
+  p.addresses[1]                      AS address0,
+  p.sources                           AS sources,
+  ST_X(p.geometry)                    AS longitude,
+  ST_Y(p.geometry)                    AS latitude,
+  ST_AsGeoJSON(p.geometry)            AS geometry_geojson
+FROM current_county p
+JOIN changes c ON c.id = p.id
+WHERE c.change_type IN ('added', 'data_changed')
+ORDER BY p.id`);
+}
+
+/**
+ * Map a current-release changed place into loader JSON.
+ *
+ * @param {object} params Mapper inputs.
+ * @param {JsonObject} params.row DuckDB row.
+ * @param {IncrementalExtractOptions} params.options Extraction options.
+ * @param {readonly string[]} params.hostedServicePaths Committed full paths.
+ * @returns {JsonObject} Loader record.
+ */
+function mapIncrementalPlaceRow(params) {
+  const taxonomyPath = taxonomyHierarchyToPath(params.row.taxonomy_hierarchy);
+  const hosted = matchHostedService(
+    taxonomyPath,
+    params.hostedServicePaths,
+    hostedServiceRuleId(params.options.release),
+  );
+  const base = mapPlaceRow({
+    row: {
+      ...params.row,
+      overture_release: params.options.release,
+      county_fips: params.options.countyFips,
+    },
+    options: /** @type {import("./overture-places-lib.mjs").ExtractCliOptions} */ ({
+      county: params.options.county,
+      countyFips: params.options.countyFips,
+    }),
+    countyName: params.options.countyName,
+    hostedServicePaths: params.hostedServicePaths,
+    ruleId: hostedServiceRuleId(params.options.release),
+  });
+  return {
+    ...base,
+    taxonomy_hierarchy: taxonomyPathToHierarchy(taxonomyPath),
+    is_hosted_service: hosted.isHostedService,
+    hosted_service_rule: hosted.hostedServiceRule,
+  };
+}
+
+/**
+ * Read full-county diagnostics without turning unchanged rows into loader work.
+ *
+ * @param {DuckdbConnection} db DuckDB connection.
+ * @param {string} release Pinned Overture release.
+ * @param {readonly string[]} hostedServicePaths Committed full taxonomy paths.
+ * @returns {Promise<JsonObject>} Current county counters.
+ */
+async function readFullCountyCounters(db, release, hostedServicePaths) {
+  const county = await db.all(`
+SELECT
+  count(*)::BIGINT AS clip_count,
+  count(DISTINCT taxonomy.primary)::BIGINT AS distinct_taxonomy_primary
+FROM current_county`);
+  const statuses = await db.all(`
+SELECT coalesce(operating_status, '(blank)') AS status, count(*)::BIGINT AS count
+FROM current_county
+GROUP BY 1`);
+  const confidenceRows = await db.all(
+    "SELECT confidence FROM current_county WHERE confidence IS NOT NULL",
+  );
+  const hierarchyRows = await db.all(
+    "SELECT taxonomy.hierarchy AS hierarchy FROM current_county",
+  );
+  const hostedPathSet = new Set(hostedServicePaths);
+  const hostedServiceFlagCount = hierarchyRows.filter((entry) => {
+    const taxonomyPath = taxonomyHierarchyToPath(entry.hierarchy);
+    return taxonomyPath !== null && hostedPathSet.has(taxonomyPath);
+  }).length;
+  const bbox = await db.all(`
+SELECT count(*)::BIGINT AS bbox_count
+FROM read_parquet(
+       ${duckdbStringLiteral(overturePlacesParquetGlob(release))},
+       hive_partitioning = 1
+     ) p,
+     county_bbox b
+WHERE p.bbox.xmin >= b.xmin
+  AND p.bbox.xmax <= b.xmax
+  AND p.bbox.ymin >= b.ymin
+  AND p.bbox.ymax <= b.ymax`);
+  const row = county[0] ?? {};
+  /** @type {Record<string, number>} */
+  const operatingStatusCounts = {};
+  for (const status of statuses) {
+    operatingStatusCounts[String(status.status)] = Number(status.count);
+  }
+  return {
+    bboxCount: Number(bbox[0]?.bbox_count ?? row.clip_count ?? 0),
+    clipCount: Number(row.clip_count ?? 0),
+    distinctTaxonomyPrimary: Number(row.distinct_taxonomy_primary ?? 0),
+    hostedServiceFlagCount,
+    operatingStatusCounts,
+    confidenceDistribution: confidenceDistribution(
+      confidenceRows.map((entry) => Number(entry.confidence)),
+    ),
+  };
+}
+
+/**
+ * Read existing current county GERS IDs from Neon.
+ *
+ * @param {string} databaseUrl Neon connection string.
+ * @param {string} county County key.
+ * @returns {Promise<string[]>} Sorted current GERS IDs.
+ */
+async function readCurrentCountyGersIds(databaseUrl, county) {
+  const pg = await import("pg");
+  const client = new pg.default.Client({
+    connectionString: databaseUrl,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 20_000,
+    application_name: "oracle-node-overture-refresh-extract",
+  });
+  await client.connect();
+  try {
+    const result = await client.query(
+      `SELECT gers_id
+       FROM business_locations
+       WHERE source_system = 'overture_places'
+         AND county_key = $1
+         AND is_current = true
+       ORDER BY gers_id`,
+      [county],
+    );
+    return result.rows.map((row) => String(row.gers_id));
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Write JSONL records in bounded parts.
+ *
+ * @param {object} params Writer inputs.
+ * @param {readonly JsonObject[]} params.records Loader records.
+ * @param {string} params.runRoot Local run root.
+ * @param {number} params.partRecordLimit Rows per part.
+ * @returns {Promise<string[]>} Relative part paths.
+ */
+async function writeJsonlParts(params) {
+  /** @type {string[]} */
+  const parts = [];
+  for (
+    let offset = 0, partNumber = 1;
+    offset < params.records.length;
+    offset += params.partRecordLimit, partNumber += 1
+  ) {
+    const relative = `places/places-part-${String(partNumber).padStart(4, "0")}.jsonl`;
+    const records = params.records.slice(
+      offset,
+      offset + params.partRecordLimit,
+    );
+    await mkdir(path.dirname(path.join(params.runRoot, relative)), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(params.runRoot, relative),
+      records.map((record) => `${JSON.stringify(record)}\n`).join(""),
+      { encoding: "utf8", flag: "w" },
+    );
+    parts.push(relative);
+  }
+  return parts;
+}
+
+/**
+ * Upload a run-scoped local tree to internal AWS S3.
+ *
+ * @param {object} params Upload inputs.
+ * @param {string} params.localRoot Local root.
+ * @param {string} params.bucket AWS S3 bucket.
+ * @param {string} params.prefix Run-scoped key prefix.
+ * @returns {Promise<void>}
+ */
+async function uploadRunTree(params) {
+  const client = new S3Client({});
+  /**
+   * @param {string} dir Current local directory.
+   * @param {string} relative Relative key.
+   * @returns {Promise<void>}
+   */
+  const walk = async (dir, relative) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const nextRelative = relative ? `${relative}/${entry.name}` : entry.name;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath, nextRelative);
+        continue;
+      }
+      if (nextRelative.startsWith("duckdb-tmp/")) continue;
+      await client.send(
+        new PutObjectCommand({
+          Bucket: params.bucket,
+          Key: `${params.prefix.replace(/\/+$/, "")}/${nextRelative}`,
+          Body: await readFile(fullPath),
+        }),
+      );
+    }
+  };
+  await walk(params.localRoot, "");
+}
+
+/**
+ * Write formatted JSON, creating its parent directory.
+ *
+ * @param {string} filePath Destination file.
+ * @param {unknown} value JSON value.
+ * @returns {Promise<void>}
+ */
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+/**
+ * Open a promisified in-memory DuckDB connection.
+ *
+ * @returns {Promise<DuckdbConnection>} Connection wrapper.
+ */
+async function openDuckdb() {
+  const db = new duckdb.Database(":memory:");
+  return {
+    all(sql) {
+      return new Promise((resolve, reject) => {
+        db.all(sql, (error, rows) => {
+          if (error) reject(error);
+          else resolve(rows ?? []);
+        });
+      });
+    },
+    exec(sql) {
+      return new Promise((resolve, reject) => {
+        db.exec(sql, (error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+    close() {
+      return new Promise((resolve, reject) => {
+        db.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+/**
+ * @param {readonly string[]} values Input strings.
+ * @returns {string[]} Sorted unique values.
+ */
+function uniqueSorted(values) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}

--- a/scripts/extract-overture-places-changelog.mjs
+++ b/scripts/extract-overture-places-changelog.mjs
@@ -11,13 +11,7 @@
 
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { createRequire } from "node:module";
-import {
-  mkdir,
-  readFile,
-  readdir,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 
 import {
@@ -40,7 +34,10 @@ import {
   classifyPlaceChanges,
   overturePlacesChangelogGlobs,
 } from "./overture-places-refresh-lib.mjs";
-import { ensureTigerShapefile, mapPlaceRow } from "./extract-overture-places.mjs";
+import {
+  ensureTigerShapefile,
+  mapPlaceRow,
+} from "./extract-overture-places.mjs";
 
 const require = createRequire(import.meta.url);
 const duckdb = require("duckdb");
@@ -104,7 +101,9 @@ export async function runIncrementalPlacesExtract(options) {
   try {
     const duckdbTempDir = path.join(runRoot, "duckdb-tmp");
     await mkdir(duckdbTempDir, { recursive: true });
-    await db.exec("INSTALL spatial; INSTALL httpfs; LOAD spatial; LOAD httpfs;");
+    await db.exec(
+      "INSTALL spatial; INSTALL httpfs; LOAD spatial; LOAD httpfs;",
+    );
     await db.exec("SET s3_region = 'us-west-2';");
     await db.exec(
       `SET temp_directory = ${duckdbStringLiteral(duckdbTempDir)};`,
@@ -121,9 +120,9 @@ export async function runIncrementalPlacesExtract(options) {
       typeof row.column_name === "string" ? [row.column_name] : [],
     );
     const changelogSchema = assertOvertureChangelogSchema(changelogColumns);
-    const currentCountyIds = (await db.all("SELECT id FROM current_county")).map(
-      (row) => String(row.id),
-    );
+    const currentCountyIds = (
+      await db.all("SELECT id FROM current_county")
+    ).map((row) => String(row.id));
     const changelogRows = (
       await db.all(
         `SELECT DISTINCT c.id, c.change_type
@@ -213,9 +212,7 @@ export async function runIncrementalPlacesExtract(options) {
       hostedServicePaths,
     );
     const incomingDatasets = uniqueSorted(
-      changedRows.flatMap((row) =>
-        collectDatasetsFromSources(row.sources),
-      ),
+      changedRows.flatMap((row) => collectDatasetsFromSources(row.sources)),
     );
     const licenceGate = assertApprovedPlaceDatasets(incomingDatasets);
     const finishedAt = new Date();
@@ -392,10 +389,11 @@ function mapIncrementalPlaceRow(params) {
       overture_release: params.options.release,
       county_fips: params.options.countyFips,
     },
-    options: /** @type {import("./overture-places-lib.mjs").ExtractCliOptions} */ ({
-      county: params.options.county,
-      countyFips: params.options.countyFips,
-    }),
+    options:
+      /** @type {import("./overture-places-lib.mjs").ExtractCliOptions} */ ({
+        county: params.options.county,
+        countyFips: params.options.countyFips,
+      }),
     countyName: params.options.countyName,
     hostedServicePaths: params.hostedServicePaths,
     ruleId: hostedServiceRuleId(params.options.release),

--- a/scripts/overture-places-refresh-lib.mjs
+++ b/scripts/overture-places-refresh-lib.mjs
@@ -1,0 +1,530 @@
+/**
+ * Pure planning and validation helpers for the monthly Overture places refresh.
+ *
+ * The workflow uses Neon `overture_place_extractions.run_status = 'succeeded'`
+ * as the durable release source of truth. Overture STAC remains the source of
+ * truth for the newest available release. All comparisons use parsed release
+ * parts rather than lexical string ordering.
+ */
+
+import { HOSTED_SERVICE_REVIEW_LEAF_HINTS } from "./overture-places-lib.mjs";
+
+/** @typedef {"added" | "data_changed" | "removed"} ProcessedChangeType */
+
+/**
+ * @typedef {object} ParsedReleaseId
+ * @property {string} raw Original release identifier.
+ * @property {number} year Four-digit release year.
+ * @property {number} month One-based release month.
+ * @property {number} day Release day.
+ * @property {number} revision Numeric revision after the dot.
+ */
+
+/**
+ * @typedef {object} RefreshInput
+ * @property {string} county Lower-kebab county key.
+ * @property {string} countyFips Five-digit county FIPS.
+ * @property {string} boundarySource TIGER boundary token.
+ * @property {string | null} releaseOverride Optional pinned release.
+ * @property {number} costCeilingUsd Maximum approved estimated run cost.
+ * @property {boolean} dryRun True when no mutation is permitted.
+ * @property {string | null} runId Optional caller-provided run identifier.
+ */
+
+/**
+ * @typedef {object} RefreshPlan
+ * @property {"full" | "incremental" | "noop"} action Planned execution mode.
+ * @property {string} county County key.
+ * @property {string} countyFips County FIPS.
+ * @property {string} boundarySource TIGER boundary token.
+ * @property {string} release Pinned release for this run.
+ * @property {string | null} previousRelease Last successfully published release.
+ * @property {string} idempotencyKey Stable `(county, release)` key.
+ * @property {number} estimatedCostUsd Conservative estimated AWS cost.
+ * @property {number} costCeilingUsd Caller-approved ceiling.
+ * @property {boolean} withinCostCeiling Whether the plan may proceed.
+ * @property {boolean} dryRun Whether mutation is disabled.
+ * @property {number} lockExpiresAt Epoch seconds used by the county lock.
+ * @property {string} plannedAt ISO timestamp.
+ * @property {string} reason Human-readable plan decision.
+ */
+
+/**
+ * @typedef {object} ChangelogRow
+ * @property {string} id GERS identifier.
+ * @property {string} changeType Raw changelog partition value.
+ */
+
+/**
+ * @typedef {object} ClassifiedPlaceChanges
+ * @property {string[]} activeIds Added/data-changed IDs currently inside the county.
+ * @property {string[]} addedIds New IDs currently inside the county.
+ * @property {string[]} updatedIds Existing IDs still inside the county.
+ * @property {string[]} movedInIds Data-changed IDs newly assigned to the county by geometry.
+ * @property {string[]} deactivateIds Existing IDs removed or moved outside the county.
+ * @property {string[]} removedIds Existing IDs explicitly removed from the release.
+ * @property {string[]} movedOutIds Existing data-changed IDs no longer inside the county.
+ * @property {Record<ProcessedChangeType, number>} counts Counts written to the run record.
+ */
+
+/**
+ * @typedef {object} TaxonomyDriftReport
+ * @property {string} release Current Overture release.
+ * @property {string | null} previousRelease Previous successful release.
+ * @property {boolean} quarterlyRelease True for March/June/September/December.
+ * @property {string[]} configuredPaths Committed full hosted-service paths.
+ * @property {string[]} missingConfiguredPaths Configured paths absent from the county release.
+ * @property {{configuredPath: string, observedPaths: string[]}[]} repathedConfiguredPaths Same leaf under a different path.
+ * @property {string[]} unresolvedReviewCandidates Hosted-looking paths not covered by committed rules.
+ * @property {boolean} blocking Whether publication requires human taxonomy review.
+ * @property {string[]} reasons Blocking reasons.
+ */
+
+/** Columns documented and observed in Overture changelog Parquet. */
+export const REQUIRED_CHANGELOG_COLUMNS = Object.freeze([
+  "id",
+  "bbox",
+  "change_type",
+  "theme",
+  "type",
+]);
+
+/** Change partitions processed by refreshes. `unchanged` is intentionally absent. */
+export const PROCESSED_CHANGE_TYPES = Object.freeze([
+  "added",
+  "data_changed",
+  "removed",
+]);
+
+const COUNTY_KEY_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const FIPS_PATTERN = /^\d{5}$/;
+const BOUNDARY_PATTERN = /^tiger\/tl_\d{4}_us_county$/;
+const RELEASE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})\.(\d+)$/;
+
+/**
+ * Parse and validate one Overture release identifier.
+ *
+ * @param {string} release Overture release (`YYYY-MM-DD.N`).
+ * @returns {ParsedReleaseId} Numeric parts suitable for ordering.
+ */
+export function parseOvertureReleaseId(release) {
+  const match = RELEASE_PATTERN.exec(release.trim());
+  if (
+    match === null ||
+    match[1] === undefined ||
+    match[2] === undefined ||
+    match[3] === undefined ||
+    match[4] === undefined
+  ) {
+    throw new Error(`Invalid Overture release id: ${release}`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const revision = Number(match[4]);
+  const instant = new Date(Date.UTC(year, month - 1, day));
+  if (
+    instant.getUTCFullYear() !== year ||
+    instant.getUTCMonth() !== month - 1 ||
+    instant.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid Overture release date: ${release}`);
+  }
+  return { raw: release.trim(), year, month, day, revision };
+}
+
+/**
+ * Compare two Overture releases chronologically.
+ *
+ * @param {string} left Left release id.
+ * @param {string} right Right release id.
+ * @returns {-1 | 0 | 1} Ordering result.
+ */
+export function compareOvertureReleases(left, right) {
+  const a = parseOvertureReleaseId(left);
+  const b = parseOvertureReleaseId(right);
+  const aDate = Date.UTC(a.year, a.month - 1, a.day);
+  const bDate = Date.UTC(b.year, b.month - 1, b.day);
+  if (aDate < bDate) return -1;
+  if (aDate > bDate) return 1;
+  if (a.revision < b.revision) return -1;
+  if (a.revision > b.revision) return 1;
+  return 0;
+}
+
+/**
+ * Validate untrusted manual/scheduled workflow input.
+ *
+ * `costCeilingUsd` is mandatory. A disabled schedule is initially deployed with
+ * zero, so enabling it alone cannot authorize a cost-bearing refresh.
+ *
+ * @param {unknown} value Untrusted workflow input.
+ * @returns {RefreshInput} Validated input.
+ */
+export function parseRefreshInput(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Refresh input must be a JSON object");
+  }
+  const record = /** @type {Record<string, unknown>} */ (value);
+  const county = readString(record.county);
+  const countyFips = readString(record.countyFips);
+  const boundarySource = readString(record.boundarySource);
+  const releaseOverride = readNullableString(record.releaseOverride);
+  const costCeilingUsd = readFiniteNumber(record.costCeilingUsd);
+  const dryRun = record.dryRun === true;
+  const runId = readNullableString(record.runId);
+  if (county === null || !COUNTY_KEY_PATTERN.test(county)) {
+    throw new Error("county must be normalized lower-kebab");
+  }
+  if (countyFips === null || !FIPS_PATTERN.test(countyFips)) {
+    throw new Error("countyFips must be five digits");
+  }
+  if (boundarySource === null || !BOUNDARY_PATTERN.test(boundarySource)) {
+    throw new Error(
+      "boundarySource must look like tiger/tl_2024_us_county",
+    );
+  }
+  if (releaseOverride !== null) parseOvertureReleaseId(releaseOverride);
+  if (costCeilingUsd === null || costCeilingUsd < 0) {
+    throw new Error("costCeilingUsd must be a finite non-negative number");
+  }
+  return {
+    county,
+    countyFips,
+    boundarySource,
+    releaseOverride,
+    costCeilingUsd,
+    dryRun,
+    runId,
+  };
+}
+
+/**
+ * Estimate one serial Fargate workflow run.
+ *
+ * The estimate deliberately rounds up. It uses the largest configured
+ * 4-vCPU/16-GiB task size across the serial stage runtime,
+ * S3 request/data overhead, Step Functions transitions, and a safety factor.
+ * Filebase storage is outside AWS and is reported separately by the publisher.
+ *
+ * @param {"full" | "incremental"} mode Processing mode.
+ * @param {number} [estimatedChangedRows] Optional changed-row estimate.
+ * @returns {number} Estimated AWS cost in USD, rounded to cents.
+ */
+export function estimateRefreshCostUsd(mode, estimatedChangedRows = 40_191) {
+  const changedRows = Math.max(0, estimatedChangedRows);
+  const taskMinutes =
+    mode === "full"
+      ? 150
+      : 45 + Math.min(90, Math.ceil(changedRows / 2_000) * 3);
+  const vCpuHours = (taskMinutes / 60) * 4;
+  const gibHours = (taskMinutes / 60) * 16;
+  // us-east-1 Linux/x86 Fargate public rates, intentionally rounded upward.
+  const fargate = vCpuHours * 0.041 + gibHours * 0.0046;
+  const requestsAndTransitions = 0.15;
+  const transferSafetyAllowance = mode === "full" ? 0.75 : 0.35;
+  const estimate =
+    (fargate + requestsAndTransitions + transferSafetyAllowance) * 1.25;
+  return Math.ceil(estimate * 100) / 100;
+}
+
+/**
+ * Resolve a pinned plan from STAC and durable successful state.
+ *
+ * @param {object} params Planning inputs.
+ * @param {RefreshInput} params.input Validated workflow input.
+ * @param {string} params.latestRelease Latest STAC release.
+ * @param {string | null} params.lastSuccessfulRelease Latest Neon run with `run_status=succeeded`.
+ * @param {Date} [params.now] Clock used for deterministic tests.
+ * @returns {RefreshPlan} Read-only plan.
+ */
+export function buildRefreshPlan(params) {
+  const now = params.now ?? new Date();
+  const release = params.input.releaseOverride ?? params.latestRelease;
+  parseOvertureReleaseId(release);
+  parseOvertureReleaseId(params.latestRelease);
+  const previousRelease = params.lastSuccessfulRelease;
+  if (previousRelease !== null) {
+    const ordering = compareOvertureReleases(release, previousRelease);
+    if (ordering < 0) {
+      throw new Error(
+        `Refusing release rollback from ${previousRelease} to ${release}`,
+      );
+    }
+    if (ordering === 0) {
+      return {
+        action: "noop",
+        county: params.input.county,
+        countyFips: params.input.countyFips,
+        boundarySource: params.input.boundarySource,
+        release,
+        previousRelease,
+        idempotencyKey: `${params.input.county}:${release}`,
+        estimatedCostUsd: 0,
+        costCeilingUsd: params.input.costCeilingUsd,
+        withinCostCeiling: true,
+        dryRun: params.input.dryRun,
+        lockExpiresAt: Math.floor(now.getTime() / 1000) + 6 * 60 * 60,
+        plannedAt: now.toISOString(),
+        reason: `latest release ${release} is already successfully published`,
+      };
+    }
+  }
+  const action = previousRelease === null ? "full" : "incremental";
+  const estimatedCostUsd = estimateRefreshCostUsd(action);
+  return {
+    action,
+    county: params.input.county,
+    countyFips: params.input.countyFips,
+    boundarySource: params.input.boundarySource,
+    release,
+    previousRelease,
+    idempotencyKey: `${params.input.county}:${release}`,
+    estimatedCostUsd,
+    costCeilingUsd: params.input.costCeilingUsd,
+    withinCostCeiling: estimatedCostUsd <= params.input.costCeilingUsd,
+    dryRun: params.input.dryRun,
+    lockExpiresAt: Math.floor(now.getTime() / 1000) + 6 * 60 * 60,
+    plannedAt: now.toISOString(),
+    reason:
+      action === "full"
+        ? `no successful release exists; full extraction required for ${release}`
+        : `new release ${release} follows ${previousRelease}`,
+  };
+}
+
+/**
+ * Build the three public changelog partition paths used by a refresh.
+ *
+ * @param {string} release Pinned Overture release.
+ * @returns {string[]} Added/data_changed/removed S3 globs.
+ */
+export function overturePlacesChangelogGlobs(release) {
+  parseOvertureReleaseId(release);
+  return PROCESSED_CHANGE_TYPES.map(
+    (changeType) =>
+      `s3://overturemaps-us-west-2/changelog/${release}/theme=places/type=place/change_type=${changeType}/*`,
+  );
+}
+
+/**
+ * Validate a live DuckDB `DESCRIBE` result for the changelog.
+ *
+ * @param {readonly string[]} columns Column names returned by the public Parquet schema.
+ * @returns {{passed: true, columns: string[]}} Validated schema record.
+ */
+export function assertOvertureChangelogSchema(columns) {
+  const normalized = [
+    ...new Set(columns.map((column) => column.trim()).filter(Boolean)),
+  ];
+  const missing = REQUIRED_CHANGELOG_COLUMNS.filter(
+    (column) => !normalized.includes(column),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Overture changelog schema is missing required column(s): ${missing.join(", ")}`,
+    );
+  }
+  return { passed: true, columns: normalized };
+}
+
+/**
+ * Classify relevant changelog IDs using geometry-derived current membership.
+ *
+ * A `data_changed` ID currently inside the county is an update or move-in. A
+ * previously-current ID that is `removed`, or `data_changed` and no longer
+ * inside, is deactivated. Rows are never deleted and disappearance is not
+ * interpreted as closure.
+ *
+ * @param {object} params Change membership inputs.
+ * @param {readonly string[]} params.existingCurrentIds Current Neon county IDs before load.
+ * @param {readonly string[]} params.currentCountyIds Current-release IDs after bbox + `ST_Within`.
+ * @param {readonly ChangelogRow[]} params.changelogRows Relevant changelog rows.
+ * @returns {ClassifiedPlaceChanges} Deterministic classifications.
+ */
+export function classifyPlaceChanges(params) {
+  const existing = new Set(params.existingCurrentIds);
+  const current = new Set(params.currentCountyIds);
+  /** @type {Map<string, ProcessedChangeType>} */
+  const changes = new Map();
+  for (const row of params.changelogRows) {
+    if (!PROCESSED_CHANGE_TYPES.includes(row.changeType)) {
+      throw new Error(`Unsupported Overture change_type: ${row.changeType}`);
+    }
+    changes.set(row.id, /** @type {ProcessedChangeType} */ (row.changeType));
+  }
+  /** @type {string[]} */
+  const addedIds = [];
+  /** @type {string[]} */
+  const updatedIds = [];
+  /** @type {string[]} */
+  const movedInIds = [];
+  /** @type {string[]} */
+  const removedIds = [];
+  /** @type {string[]} */
+  const movedOutIds = [];
+  for (const [id, changeType] of changes) {
+    if (current.has(id) && changeType === "added") addedIds.push(id);
+    if (current.has(id) && changeType === "data_changed") {
+      if (existing.has(id)) updatedIds.push(id);
+      else movedInIds.push(id);
+    }
+    if (!existing.has(id)) continue;
+    if (changeType === "removed") removedIds.push(id);
+    if (changeType === "data_changed" && !current.has(id)) movedOutIds.push(id);
+  }
+  const sort = (values) =>
+    [...new Set(values)].sort((a, b) => a.localeCompare(b));
+  const activeIds = sort([...addedIds, ...updatedIds, ...movedInIds]);
+  const deactivateIds = sort([...removedIds, ...movedOutIds]);
+  return {
+    activeIds,
+    addedIds: sort(addedIds),
+    updatedIds: sort(updatedIds),
+    movedInIds: sort(movedInIds),
+    deactivateIds,
+    removedIds: sort(removedIds),
+    movedOutIds: sort(movedOutIds),
+    counts: {
+      added: sort(addedIds).length,
+      data_changed: sort([...updatedIds, ...movedInIds, ...movedOutIds]).length,
+      removed: sort(removedIds).length,
+    },
+  };
+}
+
+/**
+ * Compare current taxonomy paths with committed full-path hosted-service rules.
+ *
+ * @param {object} params Drift inputs.
+ * @param {string} params.release Current release.
+ * @param {string | null} params.previousRelease Previous successful release.
+ * @param {readonly string[]} params.currentPaths Distinct full hierarchy paths in current county data.
+ * @param {readonly string[]} params.configuredPaths Committed hosted-service paths.
+ * @returns {TaxonomyDriftReport} Human-review gate report.
+ */
+export function buildTaxonomyDriftReport(params) {
+  const release = parseOvertureReleaseId(params.release);
+  const quarterlyRelease = [3, 6, 9, 12].includes(release.month);
+  const currentPaths = uniqueSorted(params.currentPaths);
+  const configuredPaths = uniqueSorted(params.configuredPaths);
+  const currentSet = new Set(currentPaths);
+  const configuredSet = new Set(configuredPaths);
+  const missingConfiguredPaths = configuredPaths.filter(
+    (path) => !currentSet.has(path),
+  );
+  const repathedConfiguredPaths = missingConfiguredPaths.flatMap(
+    (configuredPath) => {
+      const leaf = taxonomyLeaf(configuredPath);
+      const observedPaths = currentPaths.filter(
+        (path) => taxonomyLeaf(path) === leaf && path !== configuredPath,
+      );
+      return observedPaths.length === 0
+        ? []
+        : [{ configuredPath, observedPaths }];
+    },
+  );
+  const unresolvedReviewCandidates = currentPaths.filter(
+    (path) =>
+      !configuredSet.has(path) &&
+      HOSTED_SERVICE_REVIEW_LEAF_HINTS.some((hint) =>
+        taxonomyLeaf(path).includes(hint),
+      ),
+  );
+  /** @type {string[]} */
+  const reasons = [];
+  if (missingConfiguredPaths.length > 0) {
+    reasons.push(
+      `${missingConfiguredPaths.length} configured hosted-service path(s) disappeared`,
+    );
+  }
+  if (repathedConfiguredPaths.length > 0) {
+    reasons.push(
+      `${repathedConfiguredPaths.length} configured hosted-service path(s) were repathed`,
+    );
+  }
+  if (quarterlyRelease && unresolvedReviewCandidates.length > 0) {
+    reasons.push(
+      `${unresolvedReviewCandidates.length} hosted-service candidate path(s) require quarterly review`,
+    );
+  }
+  return {
+    release: params.release,
+    previousRelease: params.previousRelease,
+    quarterlyRelease,
+    configuredPaths,
+    missingConfiguredPaths,
+    repathedConfiguredPaths,
+    unresolvedReviewCandidates,
+    blocking: reasons.length > 0,
+    reasons,
+  };
+}
+
+/**
+ * Return whether a place is explicitly closed from source fields.
+ *
+ * Removal/deactivation is deliberately ignored. Closure comes only from
+ * `operating_status` or Overture's documented confidence-zero signal.
+ *
+ * @param {unknown} operatingStatus Source operating status.
+ * @param {unknown} confidence Source confidence.
+ * @returns {boolean} True only for explicit closure evidence.
+ */
+export function isExplicitlyClosed(operatingStatus, confidence) {
+  return (
+    operatingStatus === "permanently_closed" ||
+    (typeof confidence === "number" && confidence === 0)
+  );
+}
+
+/**
+ * @param {unknown} value Unknown scalar.
+ * @returns {string | null} Trimmed non-empty string.
+ */
+function readString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * @param {unknown} value Unknown optional scalar.
+ * @returns {string | null} Trimmed string or null.
+ */
+function readNullableString(value) {
+  if (value === undefined || value === null || value === "") return null;
+  return readString(value);
+}
+
+/**
+ * @param {unknown} value Unknown numeric scalar.
+ * @returns {number | null} Finite number or null.
+ */
+function readFiniteNumber(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * @param {string} path Full taxonomy path.
+ * @returns {string} Final hierarchy segment.
+ */
+function taxonomyLeaf(path) {
+  const segments = path.split("/").filter(Boolean);
+  return segments[segments.length - 1] ?? "";
+}
+
+/**
+ * @param {readonly string[]} values Input values.
+ * @returns {string[]} Sorted unique non-empty values.
+ */
+function uniqueSorted(values) {
+  return [
+    ...new Set(values.map((value) => value.trim()).filter(Boolean)),
+  ].sort((a, b) => a.localeCompare(b));
+}

--- a/scripts/overture-places-refresh-lib.mjs
+++ b/scripts/overture-places-refresh-lib.mjs
@@ -180,9 +180,7 @@ export function parseRefreshInput(value) {
     throw new Error("countyFips must be five digits");
   }
   if (boundarySource === null || !BOUNDARY_PATTERN.test(boundarySource)) {
-    throw new Error(
-      "boundarySource must look like tiger/tl_2024_us_county",
-    );
+    throw new Error("boundarySource must look like tiger/tl_2024_us_county");
   }
   if (releaseOverride !== null) parseOvertureReleaseId(releaseOverride);
   if (costCeilingUsd === null || costCeilingUsd < 0) {
@@ -524,7 +522,7 @@ function taxonomyLeaf(path) {
  * @returns {string[]} Sorted unique non-empty values.
  */
 function uniqueSorted(values) {
-  return [
-    ...new Set(values.map((value) => value.trim()).filter(Boolean)),
-  ].sort((a, b) => a.localeCompare(b));
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort(
+    (a, b) => a.localeCompare(b),
+  );
 }

--- a/scripts/probe-overture-changelog-schema.mjs
+++ b/scripts/probe-overture-changelog-schema.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only public probe for Overture STAC and places changelog schema.
+ *
+ * This script performs no AWS or database writes. It resolves (or accepts) a
+ * pinned release, asks DuckDB to describe the three processed changelog
+ * partitions, validates the documented fields, and prints one small sample.
+ */
+
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+import { discoverRelease } from "./extract-overture-places.mjs";
+import {
+  assertOvertureChangelogSchema,
+  overturePlacesChangelogGlobs,
+} from "./overture-places-refresh-lib.mjs";
+
+const require = createRequire(import.meta.url);
+const duckdb = require("duckdb");
+
+/**
+ * @typedef {object} DuckdbConnection
+ * @property {(sql: string) => Promise<Record<string, unknown>[]>} all Execute a query.
+ * @property {(sql: string) => Promise<void>} exec Execute statements.
+ * @property {() => Promise<void>} close Close the database.
+ */
+
+/**
+ * Probe the live public changelog.
+ *
+ * @param {readonly string[]} argv CLI arguments.
+ * @returns {Promise<Record<string, unknown>>} Machine-readable probe result.
+ */
+export async function runChangelogSchemaProbe(argv) {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      release: { type: "string" },
+      "stac-catalog-url": { type: "string" },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  const stacUrl =
+    typeof values["stac-catalog-url"] === "string"
+      ? values["stac-catalog-url"]
+      : "https://stac.overturemaps.org/catalog.json";
+  const discovery = await discoverRelease(stacUrl);
+  const release =
+    typeof values.release === "string" ? values.release : discovery.latest;
+  const globs = overturePlacesChangelogGlobs(release);
+  const db = await openDuckdb();
+  try {
+    await db.exec("INSTALL httpfs; LOAD httpfs; SET s3_region = 'us-west-2';");
+    const parquetList = globs
+      .map((glob) => `'${glob.replaceAll("'", "''")}'`)
+      .join(", ");
+    const describe = await db.all(
+      `DESCRIBE SELECT * FROM read_parquet([${parquetList}], hive_partitioning = 1)`,
+    );
+    const columns = describe.flatMap((row) =>
+      typeof row.column_name === "string" ? [row.column_name] : [],
+    );
+    const schema = assertOvertureChangelogSchema(columns);
+    const samples = await db.all(
+      `SELECT id, bbox, change_type, theme, type
+       FROM read_parquet([${parquetList}], hive_partitioning = 1)
+       LIMIT 1`,
+    );
+    return {
+      schemaVersion: "oracle-node.overture-changelog-probe.v1",
+      stacLatest: discovery.latest,
+      release,
+      globs,
+      columns: schema.columns,
+      sample: samples[0] ?? null,
+      passed: true,
+      probedAt: new Date().toISOString(),
+    };
+  } finally {
+    await db.close();
+  }
+}
+
+/**
+ * Open a promisified in-memory DuckDB connection.
+ *
+ * @returns {Promise<DuckdbConnection>} Connection wrapper.
+ */
+async function openDuckdb() {
+  const db = new duckdb.Database(":memory:");
+  return {
+    all(sql) {
+      return new Promise((resolve, reject) => {
+        db.all(sql, (error, rows) => {
+          if (error) reject(error);
+          else resolve(rows ?? []);
+        });
+      });
+    },
+    exec(sql) {
+      return new Promise((resolve, reject) => {
+        db.exec(sql, (error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+    close() {
+      return new Promise((resolve, reject) => {
+        db.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+if (
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  runChangelogSchemaProbe(process.argv.slice(2))
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    })
+    .catch((caught) => {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      process.stderr.write(
+        `${JSON.stringify({ event: "overture_changelog_probe_failed", error: message })}\n`,
+      );
+      process.exitCode = 1;
+    });
+}

--- a/scripts/run-overture-places-refresh-stage.mjs
+++ b/scripts/run-overture-places-refresh-stage.mjs
@@ -13,12 +13,7 @@ import {
   SFNClient,
 } from "@aws-sdk/client-sfn";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import {
-  mkdir,
-  readFile,
-  readdir,
-  rm,
-} from "node:fs/promises";
+import { mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,10 +21,7 @@ import { parseArgs } from "node:util";
 import pg from "pg";
 
 import { runExport } from "./export-overture-places-table.mjs";
-import {
-  discoverRelease,
-  runExtract,
-} from "./extract-overture-places.mjs";
+import { discoverRelease, runExtract } from "./extract-overture-places.mjs";
 import { runIncrementalPlacesExtract } from "./extract-overture-places-changelog.mjs";
 import {
   buildRefreshPlan,
@@ -516,7 +508,9 @@ async function assertCatalogPointerStable(params) {
     );
   }
   if (!params.parquetUrl.includes(params.ipnsName)) {
-    throw new Error("Published parquet URL does not use the verified IPNS name");
+    throw new Error(
+      "Published parquet URL does not use the verified IPNS name",
+    );
   }
 }
 
@@ -590,9 +584,7 @@ async function uploadDirectoryToS3(params) {
   const walk = async (dir, relative) => {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const childRelative = relative
-        ? `${relative}/${entry.name}`
-        : entry.name;
+      const childRelative = relative ? `${relative}/${entry.name}` : entry.name;
       const childPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         await walk(childPath, childRelative);
@@ -768,7 +760,8 @@ if (
 ) {
   main(process.argv.slice(2)).catch(async (caught) => {
     const message = caught instanceof Error ? caught.message : String(caught);
-    const errorName = caught instanceof Error ? caught.name : "RefreshStageError";
+    const errorName =
+      caught instanceof Error ? caught.name : "RefreshStageError";
     const taskToken = process.env.TASK_TOKEN;
     if (typeof taskToken === "string" && taskToken.length > 0) {
       await new SFNClient({})

--- a/scripts/run-overture-places-refresh-stage.mjs
+++ b/scripts/run-overture-places-refresh-stage.mjs
@@ -1,0 +1,789 @@
+#!/usr/bin/env node
+
+/**
+ * Stage runner used by the Overture places Step Functions workflow.
+ *
+ * Fargate callback stages return compact JSON directly to Step Functions via a
+ * task token. Local invocation prints the same JSON. No stage logs secrets.
+ */
+
+import {
+  SendTaskFailureCommand,
+  SendTaskSuccessCommand,
+  SFNClient,
+} from "@aws-sdk/client-sfn";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+} from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import pg from "pg";
+
+import { runExport } from "./export-overture-places-table.mjs";
+import {
+  discoverRelease,
+  runExtract,
+} from "./extract-overture-places.mjs";
+import { runIncrementalPlacesExtract } from "./extract-overture-places-changelog.mjs";
+import {
+  buildRefreshPlan,
+  parseRefreshInput,
+} from "./overture-places-refresh-lib.mjs";
+
+/**
+ * @typedef {Record<string, unknown>} JsonObject
+ */
+
+/**
+ * @typedef {"plan" | "extract" | "validate" | "export" | "verify" | "finalize"} RefreshStage
+ */
+
+/**
+ * @typedef {object} RefreshPlan
+ * @property {"noop" | "full" | "incremental"} action Planned path.
+ * @property {string} county County key.
+ * @property {string} countyFips Five-digit FIPS.
+ * @property {string} boundarySource Boundary source.
+ * @property {string} release Pinned release.
+ * @property {string | null} previousRelease Previous durable release.
+ * @property {boolean} dryRun Dry-run flag.
+ * @property {string} idempotencyKey County/release key.
+ * @property {string} workBucket Internal artifact bucket.
+ * @property {string} runPrefix Internal artifact prefix.
+ * @property {string} runId Operator run identifier.
+ */
+
+/**
+ * Execute one workflow stage.
+ *
+ * @param {RefreshStage} stage Stage name.
+ * @param {JsonObject} input Step Functions or local input.
+ * @param {string | null} envFile Optional dotenv file for local validation.
+ * @returns {Promise<JsonObject>} Stage output.
+ */
+export async function runRefreshStage(stage, input, envFile = null) {
+  if (envFile !== null) loadEnvFile(envFile);
+  if (stage === "plan") return runPlanStage(input);
+  if (stage === "extract") return runExtractStage(input);
+  if (stage === "validate") return runValidateStage(input);
+  if (stage === "export") return runExportStage(input);
+  if (stage === "verify") return runVerifyStage(input);
+  if (stage === "finalize") return runFinalizeStage(input);
+  throw new Error(`Unsupported Overture refresh stage: ${stage}`);
+}
+
+/**
+ * Resolve STAC and Neon durable successful state without mutation.
+ *
+ * @param {JsonObject} input Untrusted workflow input.
+ * @returns {Promise<JsonObject>} Read-only pinned plan.
+ */
+async function runPlanStage(input) {
+  const refreshInput = parseRefreshInput(input);
+  const discovery = await discoverRelease(
+    typeof input.stacCatalogUrl === "string"
+      ? input.stacCatalogUrl
+      : "https://stac.overturemaps.org/catalog.json",
+  );
+  const databaseUrl = requireDatabaseUrl();
+  const lastSuccessfulRelease = await readLastSuccessfulRelease({
+    databaseUrl,
+    county: refreshInput.county,
+  });
+  const plan = buildRefreshPlan({
+    input: refreshInput,
+    latestRelease: discovery.latest,
+    lastSuccessfulRelease,
+  });
+  const workBucket = requireString(input.workBucket, "workBucket");
+  const runId =
+    refreshInput.runId ??
+    `manual-${new Date().toISOString().replaceAll(/[:.]/g, "-")}`;
+  const runPrefix = [
+    "overture-places-refresh",
+    "runs",
+    refreshInput.county,
+    plan.release,
+    sanitizeRunId(runId),
+  ].join("/");
+  const lockNowEpoch = Math.floor(Date.now() / 1_000);
+  return {
+    ...plan,
+    stac: discovery,
+    workBucket,
+    runId,
+    runPrefix,
+    publishApproved: input.publishApproved === true,
+    lockNowEpoch,
+    lockExpiresAtEpoch: lockNowEpoch + 21_600,
+    sourceOfTruth: "neon:overture_place_extractions.run_status=succeeded",
+    zeroMutation: true,
+  };
+}
+
+/**
+ * Run the full-first-load or changelog extraction.
+ *
+ * @param {JsonObject} input Stage input containing `plan`.
+ * @returns {Promise<JsonObject>} Extract summary and S3 URI.
+ */
+async function runExtractStage(input) {
+  const plan = readPlan(input);
+  if (plan.action === "noop") {
+    throw new Error("Extract stage cannot run for a no-op plan");
+  }
+  if (plan.dryRun === true) {
+    throw new Error("Extract stage refuses dryRun=true");
+  }
+  const databaseUrl = requireDatabaseUrl();
+  const outputS3Uri = `s3://${plan.workBucket}/${plan.runPrefix}/`;
+  if (plan.action === "full") {
+    const summary = await runExtract([
+      "--county",
+      plan.county,
+      "--county-fips",
+      plan.countyFips,
+      "--county-name",
+      titleCaseCounty(plan.county),
+      "--release",
+      plan.release,
+      "--boundary-source",
+      plan.boundarySource,
+      "--hosted-service-list",
+      ".agents/skills/overture-places-ingest/config/hosted-service-categories.txt",
+      "--cache-dir",
+      "/tmp/overture-places/cache",
+      "--output-s3-uri",
+      outputS3Uri,
+      "--no-keep-parquet",
+    ]);
+    return { ...summary, artifactS3Uri: outputS3Uri };
+  }
+  if (typeof plan.previousRelease !== "string") {
+    throw new Error("Incremental plan is missing previousRelease");
+  }
+  return runIncrementalPlacesExtract({
+    county: plan.county,
+    countyFips: plan.countyFips,
+    countyName: titleCaseCounty(plan.county),
+    release: plan.release,
+    previousRelease: plan.previousRelease,
+    boundarySource: plan.boundarySource,
+    cacheDir: "/tmp/overture-places/cache",
+    hostedServiceListPath:
+      ".agents/skills/overture-places-ingest/config/hosted-service-categories.txt",
+    workDir: `/tmp/overture-places/${sanitizeRunId(plan.runId)}`,
+    outputBucket: plan.workBucket,
+    outputPrefix: plan.runPrefix,
+    databaseUrl,
+    partRecordLimit: 5_000,
+  });
+}
+
+/**
+ * Enforce incoming licence and taxonomy gates before Neon load.
+ *
+ * @param {JsonObject} input Stage input containing `extraction`.
+ * @returns {Promise<JsonObject>} Gate report.
+ */
+async function runValidateStage(input) {
+  const extraction = requireObject(input.extraction, "extraction");
+  const licenceGate = requireObject(extraction.licenceGate, "licenceGate");
+  if (licenceGate.passed !== true) {
+    const error = new Error(
+      typeof licenceGate.message === "string"
+        ? licenceGate.message
+        : "Incoming Overture licence gate failed",
+    );
+    error.name = "LicenceGateError";
+    throw error;
+  }
+  const taxonomyDrift =
+    extraction.taxonomyDrift === undefined
+      ? { blocking: false, reasons: [] }
+      : requireObject(extraction.taxonomyDrift, "taxonomyDrift");
+  if (taxonomyDrift.blocking === true) {
+    const reasons = Array.isArray(taxonomyDrift.reasons)
+      ? taxonomyDrift.reasons.map(String).join("; ")
+      : "hosted-service taxonomy drift requires review";
+    const error = new Error(reasons);
+    error.name = "TaxonomyDriftError";
+    throw error;
+  }
+  return {
+    passed: true,
+    licenceGate,
+    taxonomyDrift,
+    activeChangeCount: Number(extraction.activeChangeCount ?? 0),
+    deactivationCount: Number(extraction.deactivationCount ?? 0),
+    validatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Export the full current county table from Neon, validate it, and stage the
+ * publication artifact in internal AWS S3. This stage does not call Filebase.
+ *
+ * @param {JsonObject} input Stage input containing `plan`.
+ * @returns {Promise<JsonObject>} Export report and internal artifact URI.
+ */
+async function runExportStage(input) {
+  const plan = readPlan(input);
+  const exportRoot = `/tmp/overture-places-export/${sanitizeRunId(plan.runId)}`;
+  await rm(exportRoot, { recursive: true, force: true });
+  await mkdir(exportRoot, { recursive: true });
+  const report = await runExport([
+    "--from-neon",
+    "--county",
+    plan.county,
+    "--release",
+    plan.release,
+    "--out",
+    exportRoot,
+  ]);
+  const prefix = `${plan.runPrefix}/publish`;
+  await uploadDirectoryToS3({
+    localRoot: exportRoot,
+    bucket: plan.workBucket,
+    prefix,
+  });
+  return {
+    ...report,
+    artifactS3Uri: `s3://${plan.workBucket}/${prefix}/`,
+    published: false,
+  };
+}
+
+/**
+ * Verify the new stable IPNS target before Neon coverage is finalized.
+ *
+ * @param {JsonObject} input Stage input containing `publishResult`.
+ * @returns {Promise<JsonObject>} Verified public pointer.
+ */
+async function runVerifyStage(input) {
+  const publishResult = requireObject(input.publishResult, "publishResult");
+  requireString(publishResult.cid, "publishResult.cid");
+  requireString(publishResult.ipnsName, "publishResult.ipnsName");
+  const gatewayUrls = requireObject(
+    publishResult.gatewayUrls,
+    "publishResult.gatewayUrls",
+  );
+  const parquetUrl = requireString(
+    gatewayUrls.filebaseParquet,
+    "publishResult.gatewayUrls.filebaseParquet",
+  );
+  const indexUrl = requireString(
+    gatewayUrls.filebaseIndex,
+    "publishResult.gatewayUrls.filebaseIndex",
+  );
+  const noticeUrl = requireString(
+    gatewayUrls.filebaseNotice,
+    "publishResult.gatewayUrls.filebaseNotice",
+  );
+  const parquetResponse = await fetch(parquetUrl, {
+    headers: { Range: "bytes=0-3", "Cache-Control": "no-cache" },
+  });
+  if (!parquetResponse.ok) {
+    throw new Error(
+      `Published parquet verification returned HTTP ${parquetResponse.status}`,
+    );
+  }
+  const parquetPrefix = Buffer.from(await parquetResponse.arrayBuffer())
+    .subarray(0, 4)
+    .toString("ascii");
+  if (parquetPrefix !== "PAR1") {
+    throw new Error("Published places artifact is not Parquet");
+  }
+  const [indexResponse, noticeResponse] = await Promise.all([
+    fetch(indexUrl, { headers: { "Cache-Control": "no-cache" } }),
+    fetch(noticeUrl, { headers: { "Cache-Control": "no-cache" } }),
+  ]);
+  if (!indexResponse.ok || !noticeResponse.ok) {
+    throw new Error(
+      `Published sidecar verification failed: index=${indexResponse.status}, NOTICE=${noticeResponse.status}`,
+    );
+  }
+  const index = await indexResponse.json();
+  const indexObject = requireObject(index, "published index");
+  if (
+    indexObject.artifact !== "places-table" ||
+    typeof indexObject.rowCount !== "number"
+  ) {
+    throw new Error("Published places index has an invalid artifact/count");
+  }
+  const notice = await noticeResponse.text();
+  if (!notice.includes("Overture Maps")) {
+    throw new Error("Published NOTICE is missing Overture attribution");
+  }
+  return {
+    ...publishResult,
+    verified: true,
+    verifiedRowCount: indexObject.rowCount,
+    verifiedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Mark the run successful only after public verification and update coverage
+ * metadata as the final mutation.
+ *
+ * @param {JsonObject} input Stage input containing plan/publish result.
+ * @returns {Promise<JsonObject>} Durable finalization record.
+ */
+async function runFinalizeStage(input) {
+  const plan = readPlan(input);
+  const publishResult = requireObject(input.publishResult, "publishResult");
+  const cid = requireString(publishResult.cid, "publishResult.cid");
+  const ipnsLabel = requireString(
+    publishResult.ipnsLabel,
+    "publishResult.ipnsLabel",
+  );
+  const ipnsName = requireString(
+    publishResult.ipnsName,
+    "publishResult.ipnsName",
+  );
+  const gatewayUrls = requireObject(
+    publishResult.gatewayUrls,
+    "publishResult.gatewayUrls",
+  );
+  const parquetUrl = requireString(
+    gatewayUrls.filebaseParquet,
+    "publishResult.gatewayUrls.filebaseParquet",
+  );
+  await assertCatalogPointerStable({
+    county: plan.county,
+    ipnsName,
+    parquetUrl,
+  });
+  const databaseUrl = requireDatabaseUrl();
+  const client = createPgClient(
+    databaseUrl,
+    "oracle-node-overture-refresh-finalize",
+  );
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    const countResult = await client.query(
+      `SELECT count(*)::int AS count
+       FROM business_locations
+       WHERE source_system = 'overture_places'
+         AND county_key = $1
+         AND is_current = true`,
+      [plan.county],
+    );
+    const ingestedCount = Number(countResult.rows[0]?.count ?? 0);
+    await client.query(
+      `UPDATE overture_place_extractions
+       SET run_status = 'succeeded',
+           published_cid = $3,
+           published_ipns_name = $4,
+           finished_at = now(),
+           updated_at = now()
+       WHERE county_key = $1
+         AND overture_release = $2`,
+      [plan.county, plan.release, cid, ipnsName],
+    );
+    await client.query(
+      `INSERT INTO oracle_dataset_coverage
+         (county, source, ingested_count, expected_count, first_loaded_at,
+          last_loaded_at, cid, ipns_label)
+       VALUES ($1, 'overture_places', $2, NULL, now(), now(), $3, $4)
+       ON CONFLICT (county, source) DO UPDATE SET
+         ingested_count = EXCLUDED.ingested_count,
+         expected_count = NULL,
+         last_loaded_at = now(),
+         cid = EXCLUDED.cid,
+         ipns_label = EXCLUDED.ipns_label`,
+      [plan.county, ingestedCount, cid, ipnsLabel],
+    );
+    await client.query("COMMIT");
+    return {
+      status: "succeeded",
+      county: plan.county,
+      release: plan.release,
+      idempotencyKey: plan.idempotencyKey,
+      ingestedCount,
+      expectedCount: null,
+      cid,
+      ipnsLabel,
+      ipnsName,
+      parquetUrl,
+      finishedAt: new Date().toISOString(),
+    };
+  } catch (caught) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw caught;
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Query the latest run whose load and public pointer both completed.
+ *
+ * Before migration 0008 is deployed, the verified pilot is recognized only
+ * when its extraction has a passing licence gate and the coverage row has a CID.
+ *
+ * @param {object} params Query inputs.
+ * @param {string} params.databaseUrl Neon URL.
+ * @param {string} params.county County key.
+ * @returns {Promise<string | null>} Latest successfully published release.
+ */
+async function readLastSuccessfulRelease(params) {
+  const client = createPgClient(
+    params.databaseUrl,
+    "oracle-node-overture-refresh-plan",
+  );
+  await client.connect();
+  try {
+    try {
+      const result = await client.query(
+        `SELECT overture_release
+         FROM overture_place_extractions
+         WHERE county_key = $1
+           AND run_status = 'succeeded'
+         ORDER BY overture_release DESC
+         LIMIT 1`,
+        [params.county],
+      );
+      return result.rows[0]?.overture_release
+        ? String(result.rows[0].overture_release)
+        : null;
+    } catch (caught) {
+      if (!isUndefinedColumnError(caught)) throw caught;
+      const legacy = await client.query(
+        `SELECT e.overture_release
+         FROM overture_place_extractions e
+         JOIN oracle_dataset_coverage c
+           ON c.county = e.county_key
+          AND c.source = 'overture_places'
+          AND c.cid IS NOT NULL
+         WHERE e.county_key = $1
+           AND e.licence_gate_passed = true
+         ORDER BY e.overture_release DESC
+         LIMIT 1`,
+        [params.county],
+      );
+      return legacy.rows[0]?.overture_release
+        ? String(legacy.rows[0].overture_release)
+        : null;
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Ensure the stable catalog URL already references the same IPNS network key.
+ * Monthly refreshes update the IPNS pointer, not the catalog URL.
+ *
+ * @param {object} params Catalog inputs.
+ * @param {string} params.county County key.
+ * @param {string} params.ipnsName Stable IPNS network key.
+ * @param {string} params.parquetUrl Verified public parquet URL.
+ * @returns {Promise<void>}
+ */
+async function assertCatalogPointerStable(params) {
+  const catalog = JSON.parse(
+    await readFile("catalog/published-counties.json", "utf8"),
+  );
+  if (
+    catalog === null ||
+    typeof catalog !== "object" ||
+    !Array.isArray(catalog.counties)
+  ) {
+    throw new Error("Published county catalog has an invalid shape");
+  }
+  const county = catalog.counties.find(
+    (entry) =>
+      entry !== null &&
+      typeof entry === "object" &&
+      entry.countyKey === params.county,
+  );
+  if (
+    county === undefined ||
+    typeof county.placesTableUrl !== "string" ||
+    !county.placesTableUrl.includes(params.ipnsName)
+  ) {
+    throw new Error(
+      `Catalog placesTableUrl for ${params.county} does not use verified IPNS ${params.ipnsName}`,
+    );
+  }
+  if (!params.parquetUrl.includes(params.ipnsName)) {
+    throw new Error("Published parquet URL does not use the verified IPNS name");
+  }
+}
+
+/**
+ * Parse and execute the CLI, optionally completing a Step Functions callback.
+ *
+ * @param {readonly string[]} argv CLI arguments.
+ * @returns {Promise<void>}
+ */
+async function main(argv) {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      stage: { type: "string" },
+      "input-json": { type: "string" },
+      "env-file": { type: "string" },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  const stage = requireString(values.stage, "--stage");
+  if (
+    !["plan", "extract", "validate", "export", "verify", "finalize"].includes(
+      stage,
+    )
+  ) {
+    throw new Error(`Unsupported --stage ${stage}`);
+  }
+  const inputJson =
+    typeof values["input-json"] === "string"
+      ? values["input-json"]
+      : process.env.WORKFLOW_INPUT;
+  if (typeof inputJson !== "string") {
+    throw new Error("--input-json or WORKFLOW_INPUT is required");
+  }
+  const input = JSON.parse(inputJson);
+  const result = await runRefreshStage(
+    /** @type {RefreshStage} */ (stage),
+    requireObject(input, "input"),
+    typeof values["env-file"] === "string" ? values["env-file"] : null,
+  );
+  const taskToken = process.env.TASK_TOKEN;
+  if (typeof taskToken === "string" && taskToken.length > 0) {
+    await new SFNClient({}).send(
+      new SendTaskSuccessCommand({
+        taskToken,
+        output: JSON.stringify(result),
+      }),
+    );
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+/**
+ * Upload all files beneath a local artifact root.
+ *
+ * @param {object} params Upload inputs.
+ * @param {string} params.localRoot Local directory.
+ * @param {string} params.bucket Internal S3 bucket.
+ * @param {string} params.prefix Key prefix.
+ * @returns {Promise<void>}
+ */
+async function uploadDirectoryToS3(params) {
+  const client = new S3Client({});
+  /**
+   * @param {string} dir Current directory.
+   * @param {string} relative Relative key.
+   * @returns {Promise<void>}
+   */
+  const walk = async (dir, relative) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const childRelative = relative
+        ? `${relative}/${entry.name}`
+        : entry.name;
+      const childPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(childPath, childRelative);
+        continue;
+      }
+      await client.send(
+        new PutObjectCommand({
+          Bucket: params.bucket,
+          Key: `${params.prefix.replace(/\/+$/, "")}/${childRelative}`,
+          Body: await readFile(childPath),
+        }),
+      );
+    }
+  };
+  await walk(params.localRoot, "");
+}
+
+/**
+ * @returns {string} Required Neon connection URL.
+ */
+function requireDatabaseUrl() {
+  const value =
+    process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL ?? "";
+  if (value.trim().length === 0) {
+    throw new Error("DATABASE_URL_UNPOOLED or DATABASE_URL is required");
+  }
+  return value.trim();
+}
+
+/**
+ * @param {JsonObject} input Stage input.
+ * @returns {RefreshPlan} Validated plan object.
+ */
+function readPlan(input) {
+  const candidate =
+    input.plan !== undefined ? requireObject(input.plan, "plan") : input;
+  for (const key of [
+    "action",
+    "county",
+    "countyFips",
+    "boundarySource",
+    "release",
+    "workBucket",
+    "runPrefix",
+    "runId",
+    "idempotencyKey",
+  ]) {
+    requireString(candidate[key], `plan.${key}`);
+  }
+  if (
+    !["noop", "full", "incremental"].includes(String(candidate.action)) ||
+    typeof candidate.dryRun !== "boolean" ||
+    !(
+      candidate.previousRelease === null ||
+      typeof candidate.previousRelease === "string"
+    )
+  ) {
+    throw new Error("plan has an invalid action, dryRun, or previousRelease");
+  }
+  return /** @type {RefreshPlan} */ (candidate);
+}
+
+/**
+ * @param {string} county County key.
+ * @returns {string} Human county name.
+ */
+function titleCaseCounty(county) {
+  return county
+    .split("-")
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * @param {string} value Raw execution/run id.
+ * @returns {string} Filesystem/S3-safe run id.
+ */
+function sanitizeRunId(value) {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-").slice(0, 120);
+}
+
+/**
+ * @param {unknown} value Unknown object.
+ * @param {string} field Field name.
+ * @returns {JsonObject} Validated object.
+ */
+function requireObject(value, field) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} must be a JSON object`);
+  }
+  return /** @type {JsonObject} */ (value);
+}
+
+/**
+ * @param {unknown} value Unknown string.
+ * @param {string} field Field name.
+ * @returns {string} Non-empty string.
+ */
+function requireString(value, field) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value.trim();
+}
+
+/**
+ * @param {string} databaseUrl Neon URL.
+ * @param {string} applicationName Postgres application name.
+ * @returns {pg.Client} Configured client.
+ */
+function createPgClient(databaseUrl, applicationName) {
+  return new pg.Client({
+    connectionString: databaseUrl,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 20_000,
+    application_name: applicationName,
+  });
+}
+
+/**
+ * @param {unknown} caught PostgreSQL error.
+ * @returns {boolean} True for undefined-column SQLSTATE 42703.
+ */
+function isUndefinedColumnError(caught) {
+  return (
+    caught !== null &&
+    typeof caught === "object" &&
+    "code" in caught &&
+    caught.code === "42703"
+  );
+}
+
+/**
+ * Load dotenv-style values without overwriting explicit process variables.
+ *
+ * @param {string} envFile Dotenv path.
+ */
+function loadEnvFile(envFile) {
+  try {
+    const text = readFileSync(envFile, "utf8");
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+      const separator = trimmed.indexOf("=");
+      if (separator <= 0) continue;
+      const key = trimmed.slice(0, separator);
+      let value = trimmed.slice(separator + 1);
+      if (
+        value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'")))
+      ) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] ??= value;
+    }
+  } catch (caught) {
+    if (
+      caught !== null &&
+      typeof caught === "object" &&
+      "code" in caught &&
+      caught.code === "ENOENT"
+    ) {
+      return;
+    }
+    throw caught;
+  }
+}
+
+if (
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main(process.argv.slice(2)).catch(async (caught) => {
+    const message = caught instanceof Error ? caught.message : String(caught);
+    const errorName = caught instanceof Error ? caught.name : "RefreshStageError";
+    const taskToken = process.env.TASK_TOKEN;
+    if (typeof taskToken === "string" && taskToken.length > 0) {
+      await new SFNClient({})
+        .send(
+          new SendTaskFailureCommand({
+            taskToken,
+            error: errorName.slice(0, 256),
+            cause: message.slice(0, 32_768),
+          }),
+        )
+        .catch(() => undefined);
+    }
+    process.stderr.write(
+      `${JSON.stringify({ event: "overture_places_refresh_stage_failed", stage: process.env.REFRESH_STAGE, error: message })}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tests/scripts/overture-places-refresh-infra.test.mjs
+++ b/tests/scripts/overture-places-refresh-infra.test.mjs
@@ -82,7 +82,7 @@ describe("Overture places refresh infrastructure", () => {
     );
     expect(template).not.toContain("FilterExpression");
     expect(template).toContain(
-      "ConditionExpression\": \"attribute_not_exists(lock_key) OR expires_at < :now",
+      'ConditionExpression": "attribute_not_exists(lock_key) OR expires_at < :now',
     );
   });
 });

--- a/tests/scripts/overture-places-refresh-infra.test.mjs
+++ b/tests/scripts/overture-places-refresh-infra.test.mjs
@@ -1,0 +1,88 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const TEMPLATE_PATH = path.join(
+  REPO_ROOT,
+  "infra/overture-places-refresh/template.yaml",
+);
+
+/**
+ * Read the embedded Amazon States Language JSON from the CloudFormation file.
+ *
+ * @returns {Promise<Record<string, unknown>>} Parsed state machine definition.
+ */
+async function readStateMachineDefinition() {
+  const template = await readFile(TEMPLATE_PATH, "utf8");
+  const match = template.match(
+    /      DefinitionString: \|\n([\s\S]+?)\n\n  SchedulerRole:/,
+  );
+  if (match?.[1] === undefined) {
+    throw new Error("Could not locate Overture refresh DefinitionString");
+  }
+  const json = match[1]
+    .split("\n")
+    .map((line) => line.slice(8))
+    .join("\n");
+  return JSON.parse(json);
+}
+
+describe("Overture places refresh infrastructure", () => {
+  it("deploys the monthly schedule disabled and unapproved", async () => {
+    const template = await readFile(TEMPLATE_PATH, "utf8");
+    expect(template).toMatch(/MonthlySchedule:[\s\S]+?State: DISABLED/);
+    expect(template).toContain('"publishApproved":false');
+    expect(template).toContain("ScheduleState:\n    Value: DISABLED");
+  });
+
+  it("contains every explicit workflow gate and county lock", async () => {
+    const definition = await readStateMachineDefinition();
+    const states = /** @type {Record<string, Record<string, unknown>>} */ (
+      definition.States
+    );
+    expect(Object.keys(states)).toEqual(
+      expect.arrayContaining([
+        "Plan",
+        "AcquireCountyLock",
+        "Extract",
+        "ValidateIncoming",
+        "LoadIncremental",
+        "ExportFullCurrent",
+        "Publish",
+        "VerifyPublishedPointer",
+        "Finalize",
+        "RollbackPublishedPointer",
+      ]),
+    );
+    expect(states.ValidateIncoming?.Retry).toBeUndefined();
+    expect(states.Extract?.Retry).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          MaxAttempts: 2,
+          JitterStrategy: "FULL",
+        }),
+      ]),
+    );
+  });
+
+  it("scopes artifacts and references secrets without a DynamoDB scan filter", async () => {
+    const template = await readFile(TEMPLATE_PATH, "utf8");
+    expect(template).toContain(
+      "arn:${AWS::Partition}:s3:::${WorkBucketName}/overture-places-refresh/*",
+    );
+    expect(template).toContain("ValueFrom: !Ref DatabaseSecretArn");
+    expect(template).toContain(
+      'ValueFrom: !Sub "${FilebaseSecretArn}:FILEBASE_API_TOKEN::"',
+    );
+    expect(template).not.toContain("FilterExpression");
+    expect(template).toContain(
+      "ConditionExpression\": \"attribute_not_exists(lock_key) OR expires_at < :now",
+    );
+  });
+});

--- a/tests/scripts/overture-places-refresh.test.mjs
+++ b/tests/scripts/overture-places-refresh.test.mjs
@@ -24,12 +24,8 @@ const LEE_INPUT = {
 
 describe("Overture release planning", () => {
   it("orders revisions numerically and rejects rollbacks", () => {
-    expect(
-      compareOvertureReleases("2026-08-19.10", "2026-08-19.2"),
-    ).toBe(1);
-    expect(
-      compareOvertureReleases("2026-07-22.0", "2026-08-19.0"),
-    ).toBe(-1);
+    expect(compareOvertureReleases("2026-08-19.10", "2026-08-19.2")).toBe(1);
+    expect(compareOvertureReleases("2026-07-22.0", "2026-08-19.0")).toBe(-1);
     expect(() =>
       buildRefreshPlan({
         input: LEE_INPUT,
@@ -103,9 +99,9 @@ describe("Overture changelog contract", () => {
         "filename",
       ]),
     ).toMatchObject({ passed: true });
-    expect(() =>
-      assertOvertureChangelogSchema(["id", "change_type"]),
-    ).toThrow(/bbox/);
+    expect(() => assertOvertureChangelogSchema(["id", "change_type"])).toThrow(
+      /bbox/,
+    );
   });
 });
 

--- a/tests/scripts/overture-places-refresh.test.mjs
+++ b/tests/scripts/overture-places-refresh.test.mjs
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertOvertureChangelogSchema,
+  buildRefreshPlan,
+  buildTaxonomyDriftReport,
+  classifyPlaceChanges,
+  compareOvertureReleases,
+  isExplicitlyClosed,
+  overturePlacesChangelogGlobs,
+  parseRefreshInput,
+} from "../../scripts/overture-places-refresh-lib.mjs";
+import { runRefreshStage } from "../../scripts/run-overture-places-refresh-stage.mjs";
+
+const LEE_INPUT = {
+  county: "lee",
+  countyFips: "12071",
+  boundarySource: "tiger/tl_2024_us_county",
+  releaseOverride: null,
+  costCeilingUsd: 5,
+  dryRun: true,
+  runId: "manual-plan",
+};
+
+describe("Overture release planning", () => {
+  it("orders revisions numerically and rejects rollbacks", () => {
+    expect(
+      compareOvertureReleases("2026-08-19.10", "2026-08-19.2"),
+    ).toBe(1);
+    expect(
+      compareOvertureReleases("2026-07-22.0", "2026-08-19.0"),
+    ).toBe(-1);
+    expect(() =>
+      buildRefreshPlan({
+        input: LEE_INPUT,
+        latestRelease: "2026-07-22.0",
+        lastSuccessfulRelease: "2026-08-19.0",
+      }),
+    ).toThrow(/rollback/);
+  });
+
+  it("returns a zero-cost no-op when STAC matches durable successful state", () => {
+    const plan = buildRefreshPlan({
+      input: LEE_INPUT,
+      latestRelease: "2026-07-22.0",
+      lastSuccessfulRelease: "2026-07-22.0",
+      now: new Date("2026-08-13T00:00:00.000Z"),
+    });
+    expect(plan).toMatchObject({
+      action: "noop",
+      release: "2026-07-22.0",
+      previousRelease: "2026-07-22.0",
+      estimatedCostUsd: 0,
+      withinCostCeiling: true,
+      dryRun: true,
+      idempotencyKey: "lee:2026-07-22.0",
+    });
+  });
+
+  it("pins a newer release and requires the explicit cost ceiling", () => {
+    const input = parseRefreshInput({
+      ...LEE_INPUT,
+      dryRun: false,
+      costCeilingUsd: 0,
+    });
+    const plan = buildRefreshPlan({
+      input,
+      latestRelease: "2026-08-19.0",
+      lastSuccessfulRelease: "2026-07-22.0",
+    });
+    expect(plan.action).toBe("incremental");
+    expect(plan.release).toBe("2026-08-19.0");
+    expect(plan.estimatedCostUsd).toBeGreaterThan(0);
+    expect(plan.withinCostCeiling).toBe(false);
+    expect(() =>
+      parseRefreshInput({
+        county: "lee",
+        countyFips: "12071",
+        boundarySource: "tiger/tl_2024_us_county",
+      }),
+    ).toThrow(/costCeilingUsd/);
+  });
+});
+
+describe("Overture changelog contract", () => {
+  it("uses only added, data_changed, and removed partitions", () => {
+    const globs = overturePlacesChangelogGlobs("2026-07-22.0");
+    expect(globs).toHaveLength(3);
+    expect(globs.join("\n")).toContain("change_type=added");
+    expect(globs.join("\n")).toContain("change_type=data_changed");
+    expect(globs.join("\n")).toContain("change_type=removed");
+    expect(globs.join("\n")).not.toContain("unchanged");
+  });
+
+  it("validates the documented live changelog fields", () => {
+    expect(
+      assertOvertureChangelogSchema([
+        "id",
+        "bbox",
+        "change_type",
+        "theme",
+        "type",
+        "filename",
+      ]),
+    ).toMatchObject({ passed: true });
+    expect(() =>
+      assertOvertureChangelogSchema(["id", "change_type"]),
+    ).toThrow(/bbox/);
+  });
+});
+
+describe("move and removal semantics", () => {
+  it("upserts moves in and deactivates moves out/removals without closure inference", () => {
+    const result = classifyPlaceChanges({
+      existingCurrentIds: ["stay", "move-out", "removed"],
+      currentCountyIds: ["stay", "move-in", "added"],
+      changelogRows: [
+        { id: "stay", changeType: "data_changed" },
+        { id: "move-out", changeType: "data_changed" },
+        { id: "move-in", changeType: "data_changed" },
+        { id: "removed", changeType: "removed" },
+        { id: "added", changeType: "added" },
+      ],
+    });
+    expect(result.activeIds).toEqual(["added", "move-in", "stay"]);
+    expect(result.updatedIds).toEqual(["stay"]);
+    expect(result.movedInIds).toEqual(["move-in"]);
+    expect(result.deactivateIds).toEqual(["move-out", "removed"]);
+    expect(result.movedOutIds).toEqual(["move-out"]);
+    expect(result.removedIds).toEqual(["removed"]);
+    expect(result.counts).toEqual({
+      added: 1,
+      data_changed: 3,
+      removed: 1,
+    });
+    expect(isExplicitlyClosed("open", 0.8)).toBe(false);
+    expect(isExplicitlyClosed("permanently_closed", 0.8)).toBe(true);
+    expect(isExplicitlyClosed(null, 0)).toBe(true);
+  });
+
+  it("rejects unknown changelog classifications", () => {
+    expect(() =>
+      classifyPlaceChanges({
+        existingCurrentIds: [],
+        currentCountyIds: [],
+        changelogRows: [{ id: "x", changeType: "unchanged" }],
+      }),
+    ).toThrow(/Unsupported/);
+  });
+});
+
+describe("hosted-service taxonomy drift", () => {
+  const configured = [
+    "services_and_business/financial_service/atm",
+    "services_and_business/financial_service/trusts",
+  ];
+
+  it("blocks a quarterly release when a configured path is repathed", () => {
+    const report = buildTaxonomyDriftReport({
+      release: "2026-09-23.0",
+      previousRelease: "2026-08-19.0",
+      configuredPaths: configured,
+      currentPaths: [
+        "services_and_business/banking/atm",
+        "services_and_business/financial_service/trusts",
+      ],
+    });
+    expect(report.quarterlyRelease).toBe(true);
+    expect(report.missingConfiguredPaths).toEqual([
+      "services_and_business/financial_service/atm",
+    ]);
+    expect(report.repathedConfiguredPaths).toEqual([
+      {
+        configuredPath: "services_and_business/financial_service/atm",
+        observedPaths: ["services_and_business/banking/atm"],
+      },
+    ]);
+    expect(report.blocking).toBe(true);
+  });
+
+  it("passes when committed full paths remain stable and no candidate appears", () => {
+    const report = buildTaxonomyDriftReport({
+      release: "2026-08-19.0",
+      previousRelease: "2026-07-22.0",
+      configuredPaths: configured,
+      currentPaths: [...configured, "food_and_drink/restaurant"],
+    });
+    expect(report.blocking).toBe(false);
+    expect(report.reasons).toEqual([]);
+  });
+});
+
+describe("pre-load workflow gates", () => {
+  it("hard-stops an incoming licence failure", async () => {
+    await expect(
+      runRefreshStage("validate", {
+        extraction: {
+          licenceGate: {
+            passed: false,
+            message: "licence gate FAILED: osm present",
+          },
+          taxonomyDrift: { blocking: false, reasons: [] },
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "LicenceGateError",
+      message: expect.stringContaining("osm"),
+    });
+  });
+
+  it("hard-stops blocking quarterly taxonomy drift", async () => {
+    await expect(
+      runRefreshStage("validate", {
+        extraction: {
+          licenceGate: { passed: true },
+          taxonomyDrift: {
+            blocking: true,
+            reasons: ["configured hosted-service path disappeared"],
+          },
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "TaxonomyDriftError",
+      message: expect.stringContaining("disappeared"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- discover and pin Overture releases, no-op already-published releases, and extract only added/data-changed/removed changelog IDs
- gate loads and publication on cost, county geometry, licence, taxonomy drift, full-current export validation, and explicit operator approval
- add a serial Fargate/Step Functions workflow with a county lock, bounded retries, rollback, durable run artifacts, and a monthly schedule deployed disabled

## Dependency
- [ ] Merge https://github.com/elephant-xyz/elephant-query-db/pull/33 and publish its query-db image before deploying this stack

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (625 tests)
- [x] JavaScript check-mode typecheck for refresh scripts
- [x] live read-only STAC changelog probe
- [x] live read-only Neon/STAC plan returned no-op for `2026-07-22.0`
- [ ] CloudFormation API validation and container builds (local AWS credentials and Docker daemon unavailable)
- [ ] deploy manual stack with schedule disabled after PRs merge and image URIs/secrets are approved

Made with [Cursor](https://cursor.com)